### PR TITLE
feat(javascript): add JavaScript/TypeScript language support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,9 @@ RUN go install mvdan.cc/gofumpt@latest
 # Install govulncheck
 RUN go install golang.org/x/vuln/cmd/govulncheck@latest
 
+# === Node.js base: provides Node runtime for JS/TS tooling ===
+FROM node:22-bookworm-slim AS node-base
+
 # === Final stage ===
 FROM debian:bookworm-slim AS runtime
 
@@ -71,6 +74,12 @@ COPY lib/ /opt/devrail/lib/
 # Copy install scripts
 COPY scripts/ /opt/devrail/scripts/
 
+# Copy Node.js runtime from node-base (required for ESLint, Prettier, tsc, vitest)
+COPY --from=node-base /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-base /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
+    ln -sf ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
 # Set up environment
 ENV PATH="/opt/devrail/bin:/usr/local/go/bin:${PATH}"
 ENV DEVRAIL_LIB="/opt/devrail/lib"
@@ -95,6 +104,7 @@ RUN bash /opt/devrail/scripts/install-terraform.sh
 RUN bash /opt/devrail/scripts/install-ansible.sh
 RUN bash /opt/devrail/scripts/install-ruby.sh
 RUN bash /opt/devrail/scripts/install-go.sh
+RUN bash /opt/devrail/scripts/install-javascript.sh
 RUN bash /opt/devrail/scripts/install-universal.sh
 
 WORKDIR /workspace

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -17,7 +17,7 @@ DevRail is in **beta** (`v0.x`). The project is under active development. This d
 | **Makefile contract** | Beta | Two-layer delegation pattern works. Target names and behavior are stabilizing. |
 | **Shell conventions** | Stable | `lib/log.sh`, `lib/platform.sh`, header format, and idempotency patterns are settled. |
 | **Conventional commits** | Stable | Types, scopes, and format are finalized. |
-| **Language standards** | Beta | Python, Bash, Terraform, Ansible, Ruby, Go tool selections are set. Configuration details may shift. |
+| **Language standards** | Beta | Python, Bash, Terraform, Ansible, Ruby, Go, JavaScript/TypeScript tool selections are set. Configuration details may shift. |
 | **Coding practices** | Stable | General principles (DRY, KISS, testing, error handling) are finalized. |
 | **Git workflow** | Stable | Branch strategy, PR process, and merge policy are finalized. |
 | **Release & versioning** | Beta | Semver policy is defined. Automated release tooling is not yet implemented. |

--- a/scripts/install-javascript.sh
+++ b/scripts/install-javascript.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# scripts/install-javascript.sh — Install JavaScript/TypeScript tooling for DevRail
+#
+# Purpose: Installs JS/TS linting, formatting, security, and testing tools
+#          into the dev-toolchain container via npm.
+# Usage:   bash scripts/install-javascript.sh [--help]
+# Dependencies: node, npm, lib/log.sh, lib/platform.sh
+#
+# Tools installed:
+#   - eslint               (JavaScript/TypeScript linter)
+#   - @eslint/js            (ESLint core rules for flat config)
+#   - typescript-eslint     (TypeScript ESLint plugin for flat config)
+#   - prettier              (Opinionated code formatter)
+#   - typescript            (TypeScript compiler — tsc --noEmit for type checking)
+#   - vitest                (Fast ESM-native test runner)
+
+set -euo pipefail
+
+# --- Resolve library path ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEVRAIL_LIB="${DEVRAIL_LIB:-${SCRIPT_DIR}/../lib}"
+
+# shellcheck source=../lib/log.sh
+source "${DEVRAIL_LIB}/log.sh"
+# shellcheck source=../lib/platform.sh
+source "${DEVRAIL_LIB}/platform.sh"
+
+# --- Help ---
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  log_info "install-javascript.sh — Install JavaScript/TypeScript tooling for DevRail"
+  log_info "Usage: bash scripts/install-javascript.sh [--help]"
+  log_info "Tools: eslint, @eslint/js, typescript-eslint, prettier, typescript, vitest"
+  exit 0
+fi
+
+# --- Cleanup trap ---
+TMPDIR_CLEANUP=""
+cleanup() {
+  if [[ -n "${TMPDIR_CLEANUP}" && -d "${TMPDIR_CLEANUP}" ]]; then
+    rm -rf "${TMPDIR_CLEANUP}"
+  fi
+}
+trap cleanup EXIT
+
+# --- Main ---
+
+log_info "Starting JavaScript/TypeScript tooling installation"
+
+require_cmd "node" "node is required but not found"
+require_cmd "npm" "npm is required but not found"
+
+# Install JS/TS tools via npm (idempotent)
+readonly JS_TOOLS=(
+  "eslint"
+  "@eslint/js"
+  "typescript-eslint"
+  "prettier"
+  "typescript"
+  "vitest"
+)
+
+for tool in "${JS_TOOLS[@]}"; do
+  if npm list -g "${tool}" --depth=0 &>/dev/null; then
+    log_info "${tool} is already installed, skipping"
+  else
+    log_info "Installing ${tool}"
+    npm install -g "${tool}"
+  fi
+done
+
+log_info "JavaScript/TypeScript tooling installation complete"

--- a/tests/test-javascript.sh
+++ b/tests/test-javascript.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# tests/test-javascript.sh — Validate JavaScript/TypeScript tooling installation
+#
+# Purpose: Verifies that all JS/TS tools are installed and executable.
+# Usage:   bash tests/test-javascript.sh [--help]
+# Dependencies: lib/log.sh
+
+set -euo pipefail
+
+# --- Resolve library path ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEVRAIL_LIB="${DEVRAIL_LIB:-${SCRIPT_DIR}/../lib}"
+
+# shellcheck source=../lib/log.sh
+source "${DEVRAIL_LIB}/log.sh"
+
+# --- Help ---
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  log_info "test-javascript.sh — Validate JavaScript/TypeScript tooling installation"
+  log_info "Usage: bash tests/test-javascript.sh [--help]"
+  log_info "Checks: node, npm, eslint, prettier, tsc, vitest"
+  exit 0
+fi
+
+# --- Main ---
+
+log_info "Validating JavaScript/TypeScript tooling installation"
+
+FAILURES=0
+
+# check_tool verifies a tool is on PATH and can report its version
+check_tool() {
+  local tool="$1"
+  local version_flag="${2:---version}"
+
+  if ! command -v "${tool}" &>/dev/null; then
+    log_error "${tool} is not on PATH"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  if "${tool}" "${version_flag}" &>/dev/null; then
+    log_info "${tool} — OK"
+  else
+    log_error "${tool} found but failed to execute ${version_flag}"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+check_tool "node" "--version"
+check_tool "npm" "--version"
+check_tool "eslint" "--version"
+check_tool "prettier" "--version"
+check_tool "tsc" "--version"
+check_tool "vitest" "--version"
+
+if [[ "${FAILURES}" -gt 0 ]]; then
+  log_error "JavaScript/TypeScript tooling validation failed: ${FAILURES} tool(s) missing or broken"
+  exit 1
+fi
+
+log_info "All JavaScript/TypeScript tools validated successfully"


### PR DESCRIPTION
## Summary
- Add Node.js 22 runtime via COPY from `node:22-bookworm-slim` (same pattern as Go SDK)
- Install ESLint v9, @eslint/js, typescript-eslint, Prettier, TypeScript, Vitest via `npm install -g`
- Add `HAS_JAVASCRIPT` detection and blocks in all four Makefile internal targets (_lint, _format, _test, _security)
- `tsc --noEmit` under _lint gated on `tsconfig.json`; `npm audit` under _security gated on `package-lock.json`

## Test plan
- [ ] `docker build -t dev-toolchain:test .`
- [ ] `docker run --rm dev-toolchain:test bash tests/test-javascript.sh`
- [ ] Run all existing test suites to check for regressions
- [ ] Verify `make check` passes on a project with `javascript` in `.devrail.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)