### PR TITLE
fix(container): add clippy and rustfmt rustup components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN go install golang.org/x/vuln/cmd/govulncheck@latest
 # Provides Rust toolchain (rustup + cargo + rustc + clippy + rustfmt) and
 # installs cargo-audit and cargo-deny via cargo-binstall.
 FROM rust:1-slim-bookworm AS rust-builder
+RUN rustup component add clippy rustfmt
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -L --proto '=https' --tlsv1.2 -sSf \


### PR DESCRIPTION
## Summary
- Add `rustup component add clippy rustfmt` to the rust-builder stage in the Dockerfile
- The `rust:1-slim-bookworm` base image only ships `cargo`, `rustc`, and `rust-std` — clippy and rustfmt must be explicitly added

## Test plan
- [x] Built container locally, verified `cargo clippy --version` → `0.1.93`
- [x] Verified `rustfmt --version` → `1.8.0-stable`
- [x] Version manifest script now reports real versions instead of "unknown"
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)