### PR TITLE
chore(standards): bump conventional-commits hook to v1.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@
 repos:
   # --- Conventional Commits ---
   - repo: https://github.com/devrail-dev/pre-commit-conventional-commits
-    rev: v1.0.0
+    rev: v1.1.0
     hooks:
       - id: conventional-commits
 


### PR DESCRIPTION
## Summary
- Bumps the `pre-commit-conventional-commits` hook from v1.0.0 to v1.1.0
- v1.1.0 accepts all language and workflow scopes defined in the DevRail standard

## Test plan
- [x] `make check` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)