### PR TITLE
fix(ci): prevent version-manifest job skip on tag push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
   # Generate and attach tool version manifest to GitHub release
   version-manifest:
     needs: [build-and-push]
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: always() && needs.build-and-push.result == 'success' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Fix `version-manifest` job being silently skipped on tag pushes (e.g. v1.6.0)
- Root cause: GitHub Actions transitive `needs` chain skip behavior — when `auto-version` is skipped (tag push trigger), downstream jobs inherit the skip even through `build-and-push` which uses `always()`
- Fix: add `always()` with explicit `needs.build-and-push.result == 'success'` guard to the `version-manifest` job's `if` condition

## Test plan

- [ ] CI passes on this PR
- [ ] Next tag push (manual or scheduled) triggers the version-manifest job
- [ ] `tool-versions.json` is attached to the GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)