### PR TITLE
Install community.general Ansible collection in container

### DIFF
--- a/scripts/install-ansible.sh
+++ b/scripts/install-ansible.sh
@@ -6,8 +6,9 @@
 # Dependencies: python3, pip, lib/log.sh, lib/platform.sh
 #
 # Tools installed:
-#   - ansible-lint  (Ansible playbook/role linter — pulls ansible-core as dependency)
-#   - molecule      (Ansible role testing framework)
+#   - ansible-lint          (Ansible playbook/role linter — pulls ansible-core as dependency)
+#   - molecule              (Ansible role testing framework)
+#   - community.general     (Ansible collection — yaml callback, json_query, common modules)
 
 set -euo pipefail
 
@@ -67,6 +68,16 @@ else
   python3 -m pip install --break-system-packages molecule 2>/dev/null ||
     python3 -m pip install molecule
   log_info "molecule installed successfully"
+fi
+
+# Install community.general collection (idempotent)
+# Required for yaml callback plugin, json_query filter, and many common modules
+if ansible-galaxy collection list community.general &>/dev/null; then
+  log_info "community.general collection is already installed, skipping"
+else
+  log_info "Installing community.general Ansible collection"
+  ansible-galaxy collection install community.general
+  log_info "community.general collection installed successfully"
 fi
 
 log_info "Ansible tooling installation complete"

--- a/tests/test-ansible.sh
+++ b/tests/test-ansible.sh
@@ -50,6 +50,14 @@ check_tool() {
 check_tool "ansible-lint" "--version"
 check_tool "molecule" "--version"
 
+# Verify community.general collection is installed
+if ansible-galaxy collection list community.general &>/dev/null; then
+  log_info "community.general collection — OK"
+else
+  log_error "community.general Ansible collection is not installed"
+  FAILURES=$((FAILURES + 1))
+fi
+
 if [[ "${FAILURES}" -gt 0 ]]; then
   log_error "Ansible tooling validation failed: ${FAILURES} tool(s) missing or broken"
   exit 1


### PR DESCRIPTION
## Summary
- Add `ansible-galaxy collection install community.general` to `install-ansible.sh`
- Add collection verification to `test-ansible.sh`
- Fixes `[ERROR]: Could not load 'yaml' callback plugin` when projects use `stdout_callback = yaml` in `ansible.cfg`

## Test plan
- [ ] `make check` passes
- [ ] Container build succeeds with collection installed
- [ ] `ansible-galaxy collection list community.general` returns a result in new image
- [ ] Projects using `stdout_callback = yaml` no longer fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)