### PR TITLE
Fix ansible-galaxy collection install check

### DIFF
--- a/scripts/install-ansible.sh
+++ b/scripts/install-ansible.sh
@@ -72,7 +72,9 @@ fi
 
 # Install community.general collection (idempotent)
 # Required for yaml callback plugin, json_query filter, and many common modules
-if ansible-galaxy collection list community.general &>/dev/null; then
+# Note: ansible-galaxy collection list exits 0 even when not installed,
+# so we check the output for the collection name instead of the exit code.
+if ansible-galaxy collection list community.general 2>/dev/null | grep -q community.general; then
   log_info "community.general collection is already installed, skipping"
 else
   log_info "Installing community.general Ansible collection"

--- a/tests/test-ansible.sh
+++ b/tests/test-ansible.sh
@@ -51,7 +51,9 @@ check_tool "ansible-lint" "--version"
 check_tool "molecule" "--version"
 
 # Verify community.general collection is installed
-if ansible-galaxy collection list community.general &>/dev/null; then
+# Note: ansible-galaxy collection list exits 0 even when not installed,
+# so we check the output for the collection name instead of the exit code.
+if ansible-galaxy collection list community.general 2>/dev/null | grep -q community.general; then
   log_info "community.general collection — OK"
 else
   log_error "community.general Ansible collection is not installed"


### PR DESCRIPTION
## Summary
- `ansible-galaxy collection list community.general` exits 0 even when the collection is NOT installed
- The idempotency check always saw "success" and skipped the actual install
- Fix: pipe output through `grep -q community.general` to check if the collection actually appears in the list

This is why v1.7.0 shipped without `community.general` despite PR #13.

## Test plan
- [ ] `docker build` installs community.general successfully
- [ ] `ansible-galaxy collection list community.general` shows the collection in the new image
- [ ] `test-ansible.sh` validates the collection is present
- [ ] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)