### PR TITLE
Remove tfsec, replace with trivy config, fix gitleaks version

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -24,7 +24,7 @@ These eight rules are non-negotiable. Every developer and every AI agent must fo
 
 6. **Use the shared logging library.** No raw `echo` for status messages. Use `log_info`, `log_warn`, `log_error`, `log_debug`, and `die` from `lib/log.sh`.
 
-7. **Never suppress failing checks.** When a lint, format, security, or test check fails, fix the underlying issue. Never comment out code, add suppression annotations (`# noqa`, `# nosec`, `#tfsec:ignore`, `// nolint`), disable rules, or mark CI jobs as allowed-to-fail to bypass a failing check. If a finding is a confirmed false positive, document the justification inline alongside the tool's designated suppression mechanism.
+7. **Never suppress failing checks.** When a lint, format, security, or test check fails, fix the underlying issue. Never comment out code, add suppression annotations (`# noqa`, `# nosec`, `// nolint`), disable rules, or mark CI jobs as allowed-to-fail to bypass a failing check. If a finding is a confirmed false positive, document the justification inline alongside the tool's designated suppression mechanism.
 
 8. **Update documentation when changing behavior.** When a change affects public interfaces, configuration, CLI usage, or setup steps, update the relevant documentation (README, DEVELOPMENT.md, inline docs) in the same commit or PR. Do not leave documentation out of sync with code.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # === Builder stage: Go-based tools ===
-# Compiles Go-based tools (shfmt, tflint, tfsec, terraform-docs, trivy, gitleaks)
+# Compiles Go-based tools (shfmt, tflint, terraform-docs, trivy, gitleaks)
 FROM golang:1.24-bookworm AS go-builder
 
 ARG TARGETARCH
@@ -11,14 +11,13 @@ RUN go install mvdan.cc/sh/v3/cmd/shfmt@latest
 # Install tflint
 RUN go install github.com/terraform-linters/tflint@latest
 
-# Install tfsec
-RUN go install github.com/aquasecurity/tfsec/cmd/tfsec@latest
-
 # Install terraform-docs
 RUN go install github.com/terraform-docs/terraform-docs@latest
 
-# Install gitleaks
-RUN go install github.com/zricethezav/gitleaks/v8@latest
+# Install gitleaks (pin version + inject via ldflags so `gitleaks version` reports correctly)
+ARG GITLEAKS_VERSION=v8.30.0
+RUN go install -ldflags "-X github.com/zricethezav/gitleaks/v8/version.Version=${GITLEAKS_VERSION}" \
+    github.com/zricethezav/gitleaks/v8@${GITLEAKS_VERSION}
 
 # Install golangci-lint v2
 RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
@@ -121,7 +120,6 @@ COPY --from=go-builder /usr/local/go /usr/local/go
 # Copy Go-built binaries from builder
 COPY --from=go-builder /go/bin/shfmt /usr/local/bin/shfmt
 COPY --from=go-builder /go/bin/tflint /usr/local/bin/tflint
-COPY --from=go-builder /go/bin/tfsec /usr/local/bin/tfsec
 COPY --from=go-builder /go/bin/terraform-docs /usr/local/bin/terraform-docs
 COPY --from=go-builder /go/bin/gitleaks /usr/local/bin/gitleaks
 COPY --from=go-builder /go/bin/golangci-lint /usr/local/bin/golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -697,7 +697,7 @@ _security: _check-config
 	fi; \
 	if [ -n "$(HAS_TERRAFORM)" ]; then \
 		ran_languages="$${ran_languages}\"terraform\","; \
-		tfsec . || { overall_exit=1; failed_languages="$${failed_languages}\"terraform:tfsec\","; }; \
+		trivy config --exit-code 1 . || { overall_exit=1; failed_languages="$${failed_languages}\"terraform:trivy-config\","; }; \
 		if [ "$(DEVRAIL_FAIL_FAST)" = "1" ] && [ $$overall_exit -ne 0 ]; then \
 			end_time=$$(date +%s%3N); \
 			duration=$$((end_time - start_time)); \
@@ -886,7 +886,7 @@ _docs: _check-config
 		if [ -n "$(HAS_TERRAFORM)" ]; then \
 			_tv terraform "terraform version"; \
 			_tv tflint "tflint --version"; \
-			_tv tfsec "tfsec --version"; \
+			_tv trivy "trivy --version"; \
 			_tv checkov "checkov --version"; \
 			_tv terraform-docs "terraform-docs --version"; \
 			_tv terragrunt "terragrunt --version"; \

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ test                 Run validation tests
 |----------------|---------------------------------------------------|
 | Python         | ruff, bandit, semgrep, pytest, mypy               |
 | Bash           | shellcheck, shfmt, bats                           |
-| Terraform      | tflint, tfsec, checkov, terraform-docs, terraform, terragrunt |
+| Terraform      | tflint, trivy config, checkov, terraform-docs, terraform, terragrunt |
 | Ansible        | ansible-lint, molecule                            |
 | Ruby           | rubocop, reek, brakeman, bundler-audit, rspec, sorbet |
 | Go             | golangci-lint, gofumpt, govulncheck, go test      |

--- a/scripts/install-terraform.sh
+++ b/scripts/install-terraform.sh
@@ -8,7 +8,6 @@
 #
 # Tools installed:
 #   - tflint          (Terraform linter — built in Go builder stage)
-#   - tfsec           (Terraform security scanner — built in Go builder stage)
 #   - checkov         (IaC security scanner — installed via pip)
 #   - terraform-docs  (Terraform documentation gen — built in Go builder stage)
 #   - terraform       (Terraform CLI — downloaded from HashiCorp)
@@ -33,7 +32,7 @@ source "${DEVRAIL_LIB}/platform.sh"
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
   log_info "install-terraform.sh — Install Terraform tooling for DevRail"
   log_info "Usage: bash scripts/install-terraform.sh [--help]"
-  log_info "Tools: tflint, tfsec, checkov, terraform-docs, terraform, terragrunt"
+  log_info "Tools: tflint, checkov, terraform-docs, terraform, terragrunt"
   log_info "Note: terratest is a Go module dependency — not installed as a binary"
   exit 0
 fi
@@ -58,13 +57,6 @@ if command -v tflint &>/dev/null; then
   log_info "tflint is already installed"
 else
   log_warn "tflint not found — expected to be copied from Go builder stage"
-fi
-
-# Verify tfsec is available (built in Go builder stage and copied)
-if command -v tfsec &>/dev/null; then
-  log_info "tfsec is already installed"
-else
-  log_warn "tfsec not found — expected to be copied from Go builder stage"
 fi
 
 # Verify terraform-docs is available (built in Go builder stage and copied)

--- a/scripts/report-tool-versions.sh
+++ b/scripts/report-tool-versions.sh
@@ -12,7 +12,7 @@
 # Tool ecosystems:
 #   Python    — ruff, bandit, mypy, pytest, semgrep
 #   Bash      — shellcheck, shfmt, bats
-#   Terraform — terraform, tflint, tfsec, checkov, terraform-docs
+#   Terraform — terraform, tflint, checkov, terraform-docs
 #   Ansible   — ansible-lint, molecule
 #   Ruby      — rubocop, reek, brakeman, bundler-audit, rspec, srb
 #   Go        — go, golangci-lint, gofumpt, govulncheck
@@ -101,7 +101,6 @@ _json() {
   # Terraform
   _tv terraform "terraform version"
   _tv tflint "tflint --version"
-  _tv tfsec "tfsec --version"
   _tv checkov "checkov --version"
   _tv terraform-docs "terraform-docs --version"
 

--- a/tests/test-terraform.sh
+++ b/tests/test-terraform.sh
@@ -18,7 +18,7 @@ source "${DEVRAIL_LIB}/log.sh"
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
   log_info "test-terraform.sh — Validate Terraform tooling installation"
   log_info "Usage: bash tests/test-terraform.sh [--help]"
-  log_info "Checks: tflint, tfsec, checkov, terraform-docs, terraform, terragrunt"
+  log_info "Checks: tflint, checkov, terraform-docs, terraform, terragrunt"
   exit 0
 fi
 
@@ -48,7 +48,6 @@ check_tool() {
 }
 
 check_tool "tflint" "--version"
-check_tool "tfsec" "--version"
 check_tool "checkov" "--version"
 check_tool "terraform-docs" "--version"
 check_tool "terraform" "version"


### PR DESCRIPTION
## Summary
- **Remove tfsec** — deprecated, merged into Trivy. Replace `tfsec .` with `trivy config --exit-code 1 .` in the Makefile security target
- **Fix gitleaks version** — pin to v8.30.0 with `-ldflags` so `gitleaks version` reports the actual version instead of "version is set by build process"
- Remove tfsec from Dockerfile, install-terraform.sh, test-terraform.sh, report-tool-versions.sh, README.md, DEVELOPMENT.md

## Files changed (7)
- `Dockerfile` — remove tfsec build + COPY, pin gitleaks with ldflags
- `Makefile` — replace `tfsec .` with `trivy config`, remove tfsec from `_docs`
- `scripts/install-terraform.sh` — remove tfsec verify block
- `scripts/report-tool-versions.sh` — remove tfsec from manifest
- `tests/test-terraform.sh` — remove tfsec check
- `README.md` — update tools table
- `DEVELOPMENT.md` — remove tfsec:ignore from suppression examples

## Test plan
- [ ] `make check` passes
- [ ] `gitleaks version` reports `v8.30.0` in new image
- [ ] `tfsec` is not present in new image
- [ ] `trivy config .` works for Terraform security scanning
- [ ] Tool version manifest no longer includes tfsec, gitleaks no longer shows "unknown"

🤖 Generated with [Claude Code](https://claude.com/claude-code)