### PR TITLE
Add critical rule 9: ensure DevRail Makefile is active

### DIFF
--- a/scripts/devrail-init.sh
+++ b/scripts/devrail-init.sh
@@ -366,6 +366,7 @@ See DEVELOPMENT.md for the complete reference.
 6. **Use the shared logging library.** No raw `echo` for status messages. Use `log_info`, `log_warn`, `log_error`, `log_debug`, and `die` from `lib/log.sh`.
 7. **Never suppress failing checks.** When a lint, format, security, or test check fails, fix the underlying issue. Never comment out code, add suppression annotations, disable rules, or mark CI jobs as allowed-to-fail to bypass a failing check.
 8. **Update documentation when changing behavior.** When a change affects public interfaces, configuration, CLI usage, or setup steps, update the relevant documentation (README, DEVELOPMENT.md, inline docs) in the same commit or PR. Do not leave documentation out of sync with code.
+9. **Ensure the DevRail `Makefile` is active.** GNU Make prefers `GNUmakefile` over `makefile` over `Makefile`. If the project has a `GNUmakefile` or `makefile`, the DevRail `Makefile` will be silently ignored. Merge project-specific targets into the DevRail `Makefile`, or add `include Makefile` to the existing `GNUmakefile`.
 
 ## Quick Reference
 
@@ -388,6 +389,7 @@ See DEVELOPMENT.md for the complete reference.
 6. **Use the shared logging library.** No raw `echo` for status messages. Use `log_info`, `log_warn`, `log_error`, `log_debug`, and `die` from `lib/log.sh`.
 7. **Never suppress failing checks.** When a lint, format, security, or test check fails, fix the underlying issue. Never comment out code, add suppression annotations, disable rules, or mark CI jobs as allowed-to-fail to bypass a failing check.
 8. **Update documentation when changing behavior.** When a change affects public interfaces, configuration, CLI usage, or setup steps, update the relevant documentation (README, DEVELOPMENT.md, inline docs) in the same commit or PR. Do not leave documentation out of sync with code.
+9. **Ensure the DevRail `Makefile` is active.** GNU Make prefers `GNUmakefile` over `makefile` over `Makefile`. If the project has a `GNUmakefile` or `makefile`, the DevRail `Makefile` will be silently ignored. Merge project-specific targets into the DevRail `Makefile`, or add `include Makefile` to the existing `GNUmakefile`.
 
 ## Quick Reference
 
@@ -425,6 +427,11 @@ Critical Rules:
    the relevant documentation (README, DEVELOPMENT.md, inline docs) in
    the same commit or PR. Do not leave documentation out of sync with
    code.
+9. Ensure the DevRail Makefile is active. GNU Make prefers GNUmakefile
+   over makefile over Makefile. If the project has a GNUmakefile or
+   makefile, the DevRail Makefile will be silently ignored. Merge
+   project-specific targets into the DevRail Makefile, or add
+   `include Makefile` to the existing GNUmakefile.
 
 Quick Reference:
 
@@ -467,6 +474,11 @@ Quick Reference:
          the relevant documentation (README, DEVELOPMENT.md, inline docs) in
          the same commit or PR. Do not leave documentation out of sync with
          code.
+      9. Ensure the DevRail Makefile is active. GNU Make prefers GNUmakefile
+         over makefile over Makefile. If the project has a GNUmakefile or
+         makefile, the DevRail Makefile will be silently ignored. Merge
+         project-specific targets into the DevRail Makefile, or add
+         `include Makefile` to the existing GNUmakefile.
 
       Quick Reference:
 


### PR DESCRIPTION
## Summary
- Add rule 9 to all 4 agent instruction templates in `devrail-init.sh`: CLAUDE.md, AGENTS.md, .cursorrules, .opencode/agents.yaml
- GNU Make prefers `GNUmakefile` > `makefile` > `Makefile` — projects with a `GNUmakefile` (e.g., Terraform providers) silently ignore the DevRail `Makefile`

## Test plan
- [ ] `make check` passes
- [ ] `devrail-init.sh --agents-only --yes` generates files with rule 9

🤖 Generated with [Claude Code](https://claude.com/claude-code)