### PR TITLE
Bump Go builder from 1.24 to 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # === Builder stage: Go-based tools ===
 # Compiles Go-based tools (shfmt, tflint, terraform-docs, trivy, gitleaks)
-FROM golang:1.24-bookworm AS go-builder
+FROM golang:1.25-bookworm AS go-builder
 
 ARG TARGETARCH
 ENV GOTOOLCHAIN=auto


### PR DESCRIPTION
## Summary
- Bump `golang:1.24-bookworm` → `golang:1.25-bookworm` in Dockerfile builder stage
- Fixes govulncheck failing on Go 1.25 projects ("cannot analyze packages built with newer Go version")

## Test plan
- [ ] Container builds successfully with Go 1.25
- [ ] govulncheck works on Go 1.25 projects
- [ ] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)