### PR TITLE
Pin trivy-action to SHA after supply chain attack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       # Blocking scan: OS packages only. We control the base image and can act on
       # these. ignore-unfixed skips CVEs with no Debian patch available yet.
       - name: Run trivy OS package scan (blocking)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
           severity: CRITICAL,HIGH
@@ -59,7 +59,7 @@ jobs:
       # are uploaded to the GitHub Security tab for visibility. Not blocking
       # because Go binary CVEs depend on upstream tool releases we don't control.
       - name: Run trivy full scan (SARIF, advisory)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         if: always()
         with:
           image-ref: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}


### PR DESCRIPTION
## Summary
- Pin `aquasecurity/trivy-action` from tag `@0.28.0` to SHA `@57a97c7e7821a5776cebc9bb87c984fa69cba8f1` (v0.35.0)
- Response to [supply chain attack](https://github.com/aquasecurity/trivy/discussions/10425) where all trivy-action tags before 0.35.0 were force-pushed to malicious commits containing an infostealer

## Impact assessment
- **No secrets were compromised.** Our CI runs on March 19 completed at ~04:58 UTC, approximately 13 hours before the attack window started (~17:43 UTC)
- The trivy binary inside the container (0.69.3, installed via APT) was not affected — only the GitHub Action tags were poisoned
- This is a preventive fix to ensure future CI runs use a verified, SHA-pinned action

## References
- [aquasecurity/trivy-action#541](https://github.com/aquasecurity/trivy-action/issues/541)
- [Aqua Security advisory](https://github.com/aquasecurity/trivy/discussions/10425)

🤖 Generated with [Claude Code](https://claude.com/claude-code)