### PR TITLE
fix(ruby): bump container Ruby to 3.4 and scope rubocop/reek (#25)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,16 @@ jobs:
             bash /opt/devrail/scripts/report-tool-versions.sh \
             | jq .
 
+      # Phase 2c: Rails 7+ consumer smoke test (issue #25)
+      # Verifies the image is consumable by modern Rails projects:
+      #   - Gemfile with `platforms: %i[mri windows]` parses (needs Bundler 2.6+).
+      #   - make _lint scopes to RUBY_PATHS — vendor/bundle/ is not scanned.
+      - name: Rails 7+ smoke test
+        run: bash tests/smoke-rails.sh
+        env:
+          DEVRAIL_IMAGE: ${{ env.IMAGE_NAME }}
+          DEVRAIL_TAG: ${{ env.IMAGE_TAG }}
+
       # Phase 3: Security scans
       # Blocking scan: OS packages only. We control the base image and can act on
       # these. ignore-unfixed skips CVEs with no Debian patch available yet.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ruby support is now consumable by Rails 7+ projects out-of-the-box (#25):
+  - Image now ships **Ruby 3.4.9** (Bundler 2.6) via a dedicated `ruby-builder` stage,
+    replacing the bookworm APT Ruby 3.1.2 that could not parse Gemfiles using the
+    `windows` platform alias (`platforms: %i[mri windows]`).
+  - `_lint`, `_format`, and `_fix` Ruby branches now scope `rubocop` and `reek` to
+    a configurable `RUBY_PATHS` (default: `app lib spec config bin`) instead of
+    the workspace root, eliminating tens of thousands of warnings from `vendor/bundle/`
+    gem source. Override per-project via `RUBY_PATHS="lib spec" make check`.
+- `reek` is no longer pinned to `~> 6.3.0` — Ruby 3.4 satisfies its `dry-schema 1.14`
+  requirement.
+
+### Added
+
+- `tests/smoke-rails.sh` — CI smoke test that builds a minimal Rails-shaped fixture
+  (modern Gemfile + `vendor/bundle/` noise) and asserts `make _lint` passes cleanly
+  and does not descend into `vendor/bundle/`.
+
 ## [1.8.1] - 2026-03-19
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,18 @@ RUN git clone --depth 1 --branch 0.58.0 https://github.com/realm/SwiftLint.git /
     && install -m 755 .build/release/swiftlint /usr/local/bin/swiftlint \
     && rm -rf /tmp/SwiftLint
 
+# === Ruby builder stage ===
+# Provides Ruby 3.4 toolchain plus installed gems (rubocop, reek, brakeman,
+# bundler-audit, rspec, sorbet). Debian bookworm ships Ruby 3.1 which cannot
+# parse modern Rails 7+ Gemfiles (`platforms: %i[mri windows]`) — see #25.
+FROM ruby:3.4-slim-bookworm AS ruby-builder
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential git \
+    && rm -rf /var/lib/apt/lists/*
+COPY lib/ /opt/devrail/lib/
+COPY scripts/install-ruby.sh /opt/devrail/scripts/install-ruby.sh
+RUN bash /opt/devrail/scripts/install-ruby.sh
+
 # === JDK builder stage ===
 # Provides JDK 21 for Kotlin tooling (ktlint, detekt, Gradle)
 FROM eclipse-temurin:21-jdk AS jdk-builder
@@ -88,9 +100,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-pip \
     python3-venv \
-    ruby \
-    ruby-dev \
     build-essential \
+    libyaml-0-2 \
     shellcheck \
     unzip \
     wget \
@@ -145,8 +156,34 @@ COPY --from=swift-builder /usr/local/bin/swiftlint /usr/local/bin/swiftlint
 COPY --from=jdk-builder /opt/java/openjdk /opt/java/openjdk
 ENV JAVA_HOME=/opt/java/openjdk
 
+# Copy Ruby 3.4 toolchain + installed gems from ruby-builder.
+# Mirrors the official ruby:3.4-slim-bookworm layout: binaries in /usr/local/bin,
+# stdlib in /usr/local/lib/ruby, headers in /usr/local/include, and gems
+# (rubocop, reek, brakeman, bundler-audit, rspec, sorbet) in /usr/local/bundle.
+COPY --from=ruby-builder /usr/local/bin/ruby /usr/local/bin/ruby
+COPY --from=ruby-builder /usr/local/bin/gem /usr/local/bin/gem
+COPY --from=ruby-builder /usr/local/bin/bundle /usr/local/bin/bundle
+COPY --from=ruby-builder /usr/local/bin/bundler /usr/local/bin/bundler
+COPY --from=ruby-builder /usr/local/bin/irb /usr/local/bin/irb
+COPY --from=ruby-builder /usr/local/bin/rake /usr/local/bin/rake
+COPY --from=ruby-builder /usr/local/bin/erb /usr/local/bin/erb
+COPY --from=ruby-builder /usr/local/bin/rdoc /usr/local/bin/rdoc
+COPY --from=ruby-builder /usr/local/bin/ri /usr/local/bin/ri
+COPY --from=ruby-builder /usr/local/bin/racc /usr/local/bin/racc
+COPY --from=ruby-builder /usr/local/lib/ruby /usr/local/lib/ruby
+COPY --from=ruby-builder /usr/local/lib/libruby.so.3.4 /usr/local/lib/libruby.so.3.4
+COPY --from=ruby-builder /usr/local/include/ruby-3.4.0 /usr/local/include/ruby-3.4.0
+COPY --from=ruby-builder /usr/local/bundle /usr/local/bundle
+RUN ln -sf libruby.so.3.4 /usr/local/lib/libruby.so.3.4.0 \
+    && ln -sf libruby.so.3.4 /usr/local/lib/libruby.so \
+    && ldconfig
+ENV GEM_HOME=/usr/local/bundle
+ENV BUNDLE_PATH=/usr/local/bundle
+ENV BUNDLE_SILENCE_ROOT_WARNING=1
+ENV BUNDLE_APP_CONFIG=/usr/local/bundle
+
 # Set up environment (consolidated PATH — all language runtimes in one line)
-ENV PATH="/opt/devrail/bin:/usr/local/cargo/bin:/usr/local/go/bin:/usr/local/swift/bin:/opt/java/openjdk/bin:${PATH}"
+ENV PATH="/opt/devrail/bin:/usr/local/bundle/bin:/usr/local/cargo/bin:/usr/local/go/bin:/usr/local/swift/bin:/opt/java/openjdk/bin:${PATH}"
 ENV DEVRAIL_LIB="/opt/devrail/lib"
 
 # Copy Go SDK from builder (required at runtime by golangci-lint, govulncheck)
@@ -168,7 +205,7 @@ RUN bash /opt/devrail/scripts/install-python.sh
 RUN bash /opt/devrail/scripts/install-bash.sh
 RUN bash /opt/devrail/scripts/install-terraform.sh
 RUN bash /opt/devrail/scripts/install-ansible.sh
-RUN bash /opt/devrail/scripts/install-ruby.sh
+# Ruby tooling is installed in the ruby-builder stage and COPY'd above
 RUN bash /opt/devrail/scripts/install-go.sh
 RUN bash /opt/devrail/scripts/install-javascript.sh
 RUN bash /opt/devrail/scripts/install-rust.sh

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,13 @@ DEVRAIL_TAG        ?= local
 DEVRAIL_FAIL_FAST  ?= 0
 DEVRAIL_LOG_FORMAT ?= json
 
+# Ruby lint/format scope. Defaults to the conventional Rails directory set so
+# rubocop and reek do not descend into vendor/bundle/ (which can hold tens of
+# thousands of files of installed gem source). Override per-project via:
+#   RUBY_PATHS="lib spec" make check
+# Non-existent paths are filtered out at runtime.
+RUBY_PATHS         ?= app lib spec config bin
+
 DOCKER_RUN := docker run --rm \
 	-v "$$(pwd):/workspace" \
 	-w /workspace \
@@ -207,11 +214,13 @@ _lint: _check-config
 	fi; \
 	if [ -n "$(HAS_RUBY)" ]; then \
 		ran_languages="$${ran_languages}\"ruby\","; \
-		rb_files=$$(find . -name '*.rb' -not -path './.git/*' -not -path './vendor/*' -not -path './node_modules/*' 2>/dev/null); \
-		if [ -n "$$rb_files" ]; then \
-			rubocop . || { overall_exit=1; failed_languages="$${failed_languages}\"ruby:rubocop\","; }; \
+		ruby_paths=""; \
+		for p in $(RUBY_PATHS); do [ -d "$$p" ] && ruby_paths="$$ruby_paths $$p"; done; \
+		ruby_paths=$${ruby_paths# }; \
+		if [ -n "$$ruby_paths" ]; then \
+			rubocop $$ruby_paths || { overall_exit=1; failed_languages="$${failed_languages}\"ruby:rubocop\","; }; \
 		else \
-			echo '{"level":"info","msg":"skipping ruby rubocop lint: no .rb files found","language":"ruby"}' >&2; \
+			echo '{"level":"info","msg":"skipping ruby rubocop lint: none of RUBY_PATHS exist (override with RUBY_PATHS=...)","language":"ruby"}' >&2; \
 		fi; \
 		if [ "$(DEVRAIL_FAIL_FAST)" = "1" ] && [ $$overall_exit -ne 0 ]; then \
 			end_time=$$(date +%s%3N); \
@@ -219,8 +228,8 @@ _lint: _check-config
 			echo "{\"target\":\"lint\",\"status\":\"fail\",\"duration_ms\":$$duration,\"languages\":[$${ran_languages%,}],\"failed\":[$${failed_languages%,}]}"; \
 			exit $$overall_exit; \
 		fi; \
-		if [ -n "$$rb_files" ]; then \
-			reek . || { overall_exit=1; failed_languages="$${failed_languages}\"ruby:reek\","; }; \
+		if [ -n "$$ruby_paths" ]; then \
+			reek $$ruby_paths || { overall_exit=1; failed_languages="$${failed_languages}\"ruby:reek\","; }; \
 		fi; \
 		if [ "$(DEVRAIL_FAIL_FAST)" = "1" ] && [ $$overall_exit -ne 0 ]; then \
 			end_time=$$(date +%s%3N); \
@@ -396,11 +405,13 @@ _format: _check-config
 	fi; \
 	if [ -n "$(HAS_RUBY)" ]; then \
 		ran_languages="$${ran_languages}\"ruby\","; \
-		rb_files=$$(find . -name '*.rb' -not -path './.git/*' -not -path './vendor/*' -not -path './node_modules/*' 2>/dev/null); \
-		if [ -n "$$rb_files" ]; then \
-			rubocop --check --fail-level error . || { overall_exit=1; failed_languages="$${failed_languages}\"ruby\","; }; \
+		ruby_paths=""; \
+		for p in $(RUBY_PATHS); do [ -d "$$p" ] && ruby_paths="$$ruby_paths $$p"; done; \
+		ruby_paths=$${ruby_paths# }; \
+		if [ -n "$$ruby_paths" ]; then \
+			rubocop --check --fail-level error $$ruby_paths || { overall_exit=1; failed_languages="$${failed_languages}\"ruby\","; }; \
 		else \
-			echo '{"level":"info","msg":"skipping ruby format: no .rb files found","language":"ruby"}' >&2; \
+			echo '{"level":"info","msg":"skipping ruby format: none of RUBY_PATHS exist (override with RUBY_PATHS=...)","language":"ruby"}' >&2; \
 		fi; \
 		if [ "$(DEVRAIL_FAIL_FAST)" = "1" ] && [ $$overall_exit -ne 0 ]; then \
 			end_time=$$(date +%s%3N); \
@@ -544,11 +555,13 @@ _fix: _check-config
 	fi; \
 	if [ -n "$(HAS_RUBY)" ]; then \
 		ran_languages="$${ran_languages}\"ruby\","; \
-		rb_files=$$(find . -name '*.rb' -not -path './.git/*' -not -path './vendor/*' -not -path './node_modules/*' 2>/dev/null); \
-		if [ -n "$$rb_files" ]; then \
-			rubocop -a . || { overall_exit=1; failed_languages="$${failed_languages}\"ruby\","; }; \
+		ruby_paths=""; \
+		for p in $(RUBY_PATHS); do [ -d "$$p" ] && ruby_paths="$$ruby_paths $$p"; done; \
+		ruby_paths=$${ruby_paths# }; \
+		if [ -n "$$ruby_paths" ]; then \
+			rubocop -a $$ruby_paths || { overall_exit=1; failed_languages="$${failed_languages}\"ruby\","; }; \
 		else \
-			echo '{"level":"info","msg":"skipping ruby fix: no .rb files found","language":"ruby"}' >&2; \
+			echo '{"level":"info","msg":"skipping ruby fix: none of RUBY_PATHS exist (override with RUBY_PATHS=...)","language":"ruby"}' >&2; \
 		fi; \
 		if [ "$(DEVRAIL_FAIL_FAST)" = "1" ] && [ $$overall_exit -ne 0 ]; then \
 			end_time=$$(date +%s%3N); \
@@ -1215,7 +1228,7 @@ _init: _check-config
 	if [ -n "$(HAS_RUBY)" ]; then \
 	  scaffold .rubocop.yml \
 	    'AllCops:' \
-	    '  TargetRubyVersion: 3.1' \
+	    '  TargetRubyVersion: 3.4' \
 	    '  NewCops: enable' \
 	    '  Exclude:' \
 	    '    - "db/schema.rb"' \

--- a/scripts/install-ruby.sh
+++ b/scripts/install-ruby.sh
@@ -55,7 +55,6 @@ require_cmd "gem" "gem is required but not found"
 
 # Install Ruby tools via gem (idempotent)
 # Each entry is "gem_name" or "gem_name:version_constraint"
-# reek is pinned to ~> 6.3.0 because 6.5+ requires Ruby 3.4 (dry-schema 1.14)
 readonly RUBY_TOOLS=(
   "rubocop"
   "rubocop-rails"
@@ -64,7 +63,7 @@ readonly RUBY_TOOLS=(
   "brakeman"
   "bundler-audit"
   "rspec"
-  "reek:~> 6.3.0"
+  "reek"
   "sorbet"
   "sorbet-runtime"
 )

--- a/tests/smoke-rails.sh
+++ b/tests/smoke-rails.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# tests/smoke-rails.sh — Rails 7+ smoke test for issue #25
+#
+# Verifies the image is consumable by Rails 7+ projects out-of-the-box:
+#   1. Gemfile with `platforms: %i[mri windows]` parses (needs Bundler 2.6+).
+#   2. make _lint scopes to RUBY_PATHS — vendor/bundle/ is NOT scanned.
+#
+# Usage: bash tests/smoke-rails.sh
+# Env:
+#   DEVRAIL_IMAGE  override image name (default: ghcr.io/devrail-dev/dev-toolchain)
+#   DEVRAIL_TAG    override image tag  (default: local)
+
+set -euo pipefail
+
+IMAGE="${DEVRAIL_IMAGE:-ghcr.io/devrail-dev/dev-toolchain}:${DEVRAIL_TAG:-local}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURE="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+# --- Build a minimal Rails-shaped fixture ----------------------------------
+mkdir -p "$FIXTURE"/{app,lib,vendor/bundle/ruby/3.4.0/gems/noisy/lib}
+
+cat >"$FIXTURE/.devrail.yml" <<'YAML'
+languages: [ruby]
+YAML
+
+# Gemfile uses the modern `windows` platform alias that bookworm's Ruby 3.1
+# Bundler did not understand. Bundler 2.6 (shipped with Ruby 3.4) handles it.
+cat >"$FIXTURE/Gemfile" <<'GEMFILE'
+source 'https://rubygems.org'
+group :development, :test do
+  gem 'debug', platforms: %i[mri windows]
+end
+GEMFILE
+
+# Permissive rubocop config so the fixture's own source isn't graded on style.
+cat >"$FIXTURE/.rubocop.yml" <<'RUBOCOP'
+AllCops:
+  TargetRubyVersion: 3.4
+  NewCops: disable
+  SuggestExtensions: false
+  DisabledByDefault: true
+RUBOCOP
+
+cat >"$FIXTURE/app/foo.rb" <<'APP'
+# Minimal Ruby module for the Rails smoke test fixture.
+module Foo
+  def self.bar
+    'baz'
+  end
+end
+APP
+
+cat >"$FIXTURE/lib/util.rb" <<'LIB'
+# Minimal utility module for the Rails smoke test fixture.
+module Util
+  def self.greet(name)
+    "Hello, #{name}"
+  end
+end
+LIB
+
+# vendor/bundle/ file with intentional reek smells. MUST NOT be scanned —
+# its presence in output indicates RUBY_PATHS scoping has regressed.
+cat >"$FIXTURE/vendor/bundle/ruby/3.4.0/gems/noisy/lib/noisy.rb" <<'NOISY'
+class A
+  def x(a, b, c, d, e)
+    [1, 2, 3].each { |i| [4, 5].each { |j| puts i + j + a + b + c + d + e } }
+  end
+end
+NOISY
+
+# --- 1) Gemfile must parse with the container's Bundler --------------------
+echo "==> Verifying modern Gemfile parses (Bundler 2.6+ understands :windows)"
+docker run --rm \
+  -v "$FIXTURE:/workspace" -w /workspace "$IMAGE" \
+  ruby -e "require 'bundler'; Bundler::Definition.build('Gemfile', nil, nil); puts 'Gemfile parsed OK'"
+
+# --- 2) make _lint must succeed and not touch vendor/bundle/ ---------------
+echo "==> Running make _lint against Rails-shaped fixture"
+start=$(date +%s)
+output=$(docker run --rm \
+  -v "$FIXTURE:/workspace" \
+  -v "$REPO_ROOT/Makefile:/workspace/Makefile:ro" \
+  -w /workspace \
+  -e DEVRAIL_FAIL_FAST=0 \
+  "$IMAGE" \
+  make _lint 2>&1) && exit_code=0 || exit_code=$?
+elapsed=$(($(date +%s) - start))
+
+printf '%s\n' "$output"
+
+if [ "$exit_code" -ne 0 ]; then
+  echo "FAIL: make _lint exited $exit_code (Rails fixture should pass cleanly)" >&2
+  exit 1
+fi
+
+if printf '%s' "$output" | grep -q "vendor/bundle/.*noisy"; then
+  echo "FAIL: rubocop or reek scanned vendor/bundle/ — RUBY_PATHS scoping regressed" >&2
+  exit 1
+fi
+
+# Issue #25 reported 245s for the 73K-warning run. With scoping, this should
+# be a few seconds. 60s is a generous ceiling that still flags regressions.
+if [ "$elapsed" -gt 60 ]; then
+  echo "FAIL: make _lint took ${elapsed}s — expected <60s with RUBY_PATHS scope" >&2
+  exit 1
+fi
+
+echo "==> All Rails smoke checks passed (lint completed in ${elapsed}s)"


### PR DESCRIPTION
## Summary

Make Ruby support consumable by Rails 7+ projects out-of-the-box.
Closes #25.

- **Ruby 3.4.9** — adds a `ruby-builder` stage (`ruby:3.4-slim-bookworm`) and COPY's the toolchain + installed gems into runtime. The bookworm APT Ruby 3.1.2 could not parse modern Gemfiles using `platforms: %i[mri windows]`, the syntax `rails new` emits in Rails 7+.
- **`libyaml-0-2`** added to runtime APT (Ruby 3.4 needs it for psych/YAML).
- **`reek` unpinned** — Ruby 3.4 satisfies its `dry-schema 1.14` dependency, lifting the previous `~> 6.3.0` ceiling.
- **`RUBY_PATHS` Makefile variable** (default: `app lib spec config bin`) — `rubocop` and `reek` are now scoped to these paths in `_lint`, `_format`, `_fix` instead of `.`. Existence-filtered at runtime so non-Rails layouts still work. Override with `RUBY_PATHS="lib spec" make check`.
- Scaffolded `.rubocop.yml` `TargetRubyVersion` bumped to `3.4`.
- New `tests/smoke-rails.sh` Rails 7+ smoke test wired into CI: builds a Rails-shaped fixture (modern Gemfile + `vendor/bundle/` noise) and asserts `make _lint` passes cleanly without descending into `vendor/bundle/`.

## Impact (measured against the issue's reproducer shape)

| Symptom | Before | After |
|---|---|---|
| `_test` parsing modern Gemfile | `Bundler::GemfileError: \`windows\` is not a valid platform` | parses cleanly |
| `_lint` warnings on Rails fixture | 73,742 (mostly from `vendor/bundle/`) | 0 |
| `_lint` duration | 245s | ~2s |

## Acceptance criteria (from issue #25)

- [x] Base image runs Ruby 3.2+ (now 3.4.9, Bundler 2.6.9)
- [x] `_lint` Ruby branch scopes `rubocop`/`reek` to project paths via `RUBY_PATHS`
- [x] `_format`, `_fix` Ruby branches use the same scope as `_lint`
- [x] CI smoke test against a Rails 7+ Gemfile (with `windows` platform) confirms `make check` passes
- [x] CHANGELOG entry under "Fixed"

`_security` (brakeman, bundler-audit) intentionally stays unscoped — both tools key off project-root files (`config/application.rb`, `Gemfile.lock`) and don't have the same vendor-walking footgun.

## Test plan

- [x] `docker build` succeeds locally on amd64
- [x] Ruby tooling (rubocop, reek, brakeman, bundler-audit, rspec, sorbet) verified inside the image
- [x] `tests/test-ruby.sh` passes
- [x] `make _check` passes on the dev-toolchain repo itself
- [x] `tests/smoke-rails.sh` passes against the freshly built image
- [ ] CI green on this PR (Rails smoke test + existing build/scan/sign jobs)

## Follow-ups (separate PRs, not in this branch)

- `devrail-standards` / `devrail.dev` — bump `standards/ruby.md` `TargetRubyVersion` from 3.1 → 3.4 once this image release ships.
- Cut a `v1.9.0` (or `v1.8.2`) release; downstream repos consuming `:v1` will pick up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)