### PR TITLE
feat(makefile): .devrail.yml env: passthrough + ANSIBLE_ROLES_PATH auto-detect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `tests/smoke-rails.sh` — CI smoke test that builds a minimal Rails-shaped fixture
   (modern Gemfile + `vendor/bundle/` noise) and asserts `make _lint` passes cleanly
   and does not descend into `vendor/bundle/`.
+- `.devrail.yml` `env:` section is now passed through to the container as
+  `-e KEY=VALUE` flags on `docker run`. Lets projects declare environment
+  variables (e.g. `ANSIBLE_ROLES_PATH`, `ANSIBLE_COLLECTIONS_PATH`) that
+  tools inside the container need. Schema documented in
+  `standards/devrail-yml-schema.md`.
+- `_lint` Ansible branch now auto-detects `ANSIBLE_ROLES_PATH` from
+  `ansible.cfg` (or `ansible/ansible.cfg`) when the env var is not set
+  explicitly. Resolves a common stumble where `ansible-lint` cannot find
+  roles in projects that keep their config under an `ansible/` subdirectory.
+  Explicit configuration via `.devrail.yml` `env:` always wins.
 
 ## [1.8.1] - 2026-03-19
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,11 @@ DEVRAIL_IMAGE      ?= ghcr.io/devrail-dev/dev-toolchain
 DEVRAIL_TAG        ?= local
 DEVRAIL_FAIL_FAST  ?= 0
 DEVRAIL_LOG_FORMAT ?= json
+DEVRAIL_CONFIG     := .devrail.yml
+
+# Read project-specific env vars from .devrail.yml `env:` section and inject
+# them as `-e KEY=VALUE` into DOCKER_RUN. Empty/missing section is a no-op.
+DEVRAIL_ENV_FLAGS := $(shell yq -r '.env // {} | to_entries | .[] | "-e " + .key + "=" + .value' $(DEVRAIL_CONFIG) 2>/dev/null)
 
 # Ruby lint/format scope. Defaults to the conventional Rails directory set so
 # rubocop and reek do not descend into vendor/bundle/ (which can hold tens of
@@ -33,6 +38,7 @@ DOCKER_RUN := docker run --rm \
 	-w /workspace \
 	-e DEVRAIL_FAIL_FAST=$(DEVRAIL_FAIL_FAST) \
 	-e DEVRAIL_LOG_FORMAT=$(DEVRAIL_LOG_FORMAT) \
+	$(DEVRAIL_ENV_FLAGS) \
 	$(DEVRAIL_IMAGE):$(DEVRAIL_TAG)
 
 .DEFAULT_GOAL := help
@@ -40,7 +46,6 @@ DOCKER_RUN := docker run --rm \
 # ---------------------------------------------------------------------------
 # .devrail.yml language detection (runs inside container where yq is available)
 # ---------------------------------------------------------------------------
-DEVRAIL_CONFIG := .devrail.yml
 LANGUAGES      := $(shell yq '.languages[]' $(DEVRAIL_CONFIG) 2>/dev/null)
 HAS_PYTHON     := $(filter python,$(LANGUAGES))
 HAS_BASH       := $(filter bash,$(LANGUAGES))
@@ -204,6 +209,23 @@ _lint: _check-config
 	fi; \
 	if [ -n "$(HAS_ANSIBLE)" ]; then \
 		ran_languages="$${ran_languages}\"ansible\","; \
+		if [ -z "$${ANSIBLE_ROLES_PATH:-}" ]; then \
+			for _acfg in ansible.cfg ansible/ansible.cfg; do \
+				if [ -f "$$_acfg" ]; then \
+					_rdir=$$(grep -E '^\s*roles_path\s*=' "$$_acfg" 2>/dev/null | head -1 | cut -d= -f2 | tr -d ' '); \
+					if [ -n "$$_rdir" ]; then \
+						_cdir=$$(dirname "$$_acfg"); \
+						if [ "$$_cdir" != "." ]; then \
+							export ANSIBLE_ROLES_PATH="$$_cdir/$$_rdir"; \
+						else \
+							export ANSIBLE_ROLES_PATH="$$_rdir"; \
+						fi; \
+						echo "{\"level\":\"info\",\"msg\":\"auto-detected ANSIBLE_ROLES_PATH=$${ANSIBLE_ROLES_PATH}\",\"language\":\"ansible\"}" >&2; \
+						break; \
+					fi; \
+				fi; \
+			done; \
+		fi; \
 		ansible-lint || { overall_exit=1; failed_languages="$${failed_languages}\"ansible\","; }; \
 		if [ "$(DEVRAIL_FAIL_FAST)" = "1" ] && [ $$overall_exit -ne 0 ]; then \
 			end_time=$$(date +%s%3N); \


### PR DESCRIPTION
## Summary

Two small ergonomics fixes for projects whose tools need environment variables that depend on project layout. Both are already documented in the planning repo's `standards/devrail-yml-schema.md` (commit `bef5f6d`); this PR ships the implementation.

- **`.devrail.yml env:` passthrough.** `DOCKER_RUN` now appends `-e KEY=VALUE` for each entry in the `.devrail.yml` `env:` section (extracted via `yq` at make-time). Empty or missing section is a no-op.
- **`ANSIBLE_ROLES_PATH` auto-detect.** The `_lint` Ansible branch now reads `roles_path` from `ansible.cfg` or `ansible/ansible.cfg` when the env var is not already set. Resolves the common stumble where `ansible-lint` cannot find roles in projects that keep their config under an `ansible/` subdirectory. Explicit `.devrail.yml` `env:` configuration always wins.
- **Bug fix in the same diff:** `DEVRAIL_CONFIG := .devrail.yml` is now defined above `DEVRAIL_ENV_FLAGS` so its `:=` immediate-expansion sees the right path. Without this, \`yq\` was being handed an empty path argument and silently falling back to (closed) stdin, leaving \`DEVRAIL_ENV_FLAGS\` always empty.

## Example

\`\`\`yaml
# .devrail.yml
languages: [ansible]
env:
  ANSIBLE_ROLES_PATH: ansible/roles
  ANSIBLE_COLLECTIONS_PATH: ansible/collections
\`\`\`

\`make lint\` now invokes the container with \`-e ANSIBLE_ROLES_PATH=ansible/roles -e ANSIBLE_COLLECTIONS_PATH=ansible/collections\`.

For projects that prefer to leave \`.devrail.yml\` minimal, the auto-detect picks up:

\`\`\`ini
# ansible/ansible.cfg
[defaults]
roles_path = roles
\`\`\`

…and emits \`{"level":"info","msg":"auto-detected ANSIBLE_ROLES_PATH=ansible/roles","language":"ansible"}\` before invoking \`ansible-lint\`.

## Test plan

- [x] yq extraction returns expected \`-e KEY=VALUE\` flags from a fixture .devrail.yml
- [x] \`make -n\` shows \`DEVRAIL_ENV_FLAGS\` expanded into \`DOCKER_RUN\`
- [x] Container env vars verified end-to-end (\`docker run … bash -c 'echo \$CUSTOM_KEY'\`)
- [x] Ansible auto-detect: fixture with \`ansible/ansible.cfg\` produces the expected log line and \`ansible-lint\` passes
- [x] \`make _check\` passes on the dev-toolchain repo itself
- [ ] CI green (build/scan/sign jobs unchanged from main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)