### PR TITLE
feat(makefile): plugin manifest parser and loader prelude (Story 13.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,16 @@ jobs:
           DEVRAIL_IMAGE: ${{ env.IMAGE_NAME }}
           DEVRAIL_TAG: ${{ env.IMAGE_TAG }}
 
+      # Phase 2d: Plugin loader smoke test (Story 13.2)
+      # Verifies the v1 plugin manifest validator + loader prelude:
+      #   - validator unit cases (valid + 4 negative fixtures)
+      #   - integration: no plugins / valid plugin / invalid plugin
+      - name: Plugin loader smoke test
+        run: bash tests/test-plugin-loader.sh
+        env:
+          DEVRAIL_IMAGE: ${{ env.IMAGE_NAME }}
+          DEVRAIL_TAG: ${{ env.IMAGE_TAG }}
+
       # Phase 3: Security scans
       # Blocking scan: OS packages only. We control the base image and can act on
       # these. ignore-unfixed skips CVEs with no Debian patch available yet.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Plugin manifest parser and loader prelude (Story 13.2, Epic 13 / v1.10.0).
+  - New `scripts/plugin-validator.sh` — validates a `plugin.devrail.yml`
+    against schema_version=1 and emits structured `error`-level events for
+    every violation cumulatively (does not fail-fast on the first violation).
+  - New `lib/version.sh` — `version_gte` semver helper plus
+    `get_devrail_version` (reads `DEVRAIL_VERSION` env, then
+    `/opt/devrail/VERSION`, else `0.0.0-dev`).
+  - New `_plugins-load` Makefile target — runs as a prerequisite of `_check`,
+    `_lint`, `_format`, `_fix`, `_test`, `_security`. Iterates `.devrail.yml`
+    `plugins:` entries, locates each manifest under
+    `${DEVRAIL_PLUGINS_DIR:-/opt/devrail/plugins}/<slug>/plugin.devrail.yml`,
+    validates each, writes a parsed cache to
+    `${DEVRAIL_PLUGINS_CACHE:-/tmp/devrail-plugins-loaded.yaml}`, and exits 2
+    (misconfig) on any violation before any tool runs.
+  - Dockerfile records image version at build time via `ARG DEVRAIL_VERSION`
+    (default `0.0.0-dev`) → `/opt/devrail/VERSION` and the
+    `org.opencontainers.image.version` label.
+  - Behaviour without a `plugins:` section is unchanged — the loader emits a
+    single info event and exits 0.
+- `tests/test-plugin-loader.sh` — five validator unit cases against checked-in
+  fixtures plus three loader integration cases (no plugins / valid plugin /
+  invalid plugin). Wired into `.github/workflows/ci.yml`.
 - `tests/smoke-rails.sh` — fourth assertion: with a project-local
   `.bundle/config` declaring `BUNDLE_PATH: vendor/bundle`, the container
   honours it (validates Gap A's fix end-to-end).

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,10 +83,15 @@ FROM node:22-bookworm-slim AS node-base
 FROM debian:bookworm-slim AS runtime
 
 ARG TARGETARCH
+# Image semver, written into /opt/devrail/VERSION so the plugin loader can
+# enforce `devrail_min_version` (Story 13.2). Defaults to 0.0.0-dev for local
+# builds; CI/release passes `--build-arg DEVRAIL_VERSION=$(git describe ...)`.
+ARG DEVRAIL_VERSION=0.0.0-dev
 
 LABEL org.opencontainers.image.source="https://github.com/devrail-dev/dev-toolchain"
 LABEL org.opencontainers.image.description="DevRail developer toolchain container"
 LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.version="${DEVRAIL_VERSION}"
 
 # Base system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -132,6 +137,11 @@ COPY scripts/ /opt/devrail/scripts/
 
 # Copy default configuration files
 COPY config/ /opt/devrail/config/
+
+# Record image version for the plugin loader (Story 13.2). Read by
+# lib/version.sh:get_devrail_version. Local builds default to 0.0.0-dev,
+# which version_gte treats as "unknown" and lets pass.
+RUN printf '%s' "${DEVRAIL_VERSION}" >/opt/devrail/VERSION
 
 # Copy Node.js runtime from node-base (required for ESLint, Prettier, tsc, vitest)
 COPY --from=node-base /usr/local/bin/node /usr/local/bin/node

--- a/Makefile
+++ b/Makefile
@@ -176,8 +176,54 @@ _check-config:
 		exit 2; \
 	fi
 
+# --- _plugins-load: validate every plugin manifest declared in .devrail.yml ---
+# Story 13.2: runs as a prerequisite of every language-touching target. Exits 2
+# (misconfig) if any manifest is invalid, so no tool runs against a broken
+# plugin set. The fetcher (Story 13.3) populates manifest files at the
+# resolved location; tests override DEVRAIL_PLUGINS_DIR to point at fixtures.
+.PHONY: _plugins-load
+_plugins-load: _check-config
+	@plugins_dir="$${DEVRAIL_PLUGINS_DIR:-/opt/devrail/plugins}"; \
+	cache_file="$${DEVRAIL_PLUGINS_CACHE:-/tmp/devrail-plugins-loaded.yaml}"; \
+	plugin_count=$$(yq -r '.plugins // [] | length' $(DEVRAIL_CONFIG) 2>/dev/null || echo 0); \
+	if [ "$$plugin_count" = "0" ]; then \
+		echo '{"level":"info","msg":"no plugins declared","language":"_plugins","script":"_plugins-load"}' >&2; \
+		printf 'plugins: []\n' >"$$cache_file"; \
+		exit 0; \
+	fi; \
+	echo "{\"level\":\"info\",\"msg\":\"plugin loader started\",\"plugin_count\":$$plugin_count,\"language\":\"_plugins\",\"script\":\"_plugins-load\"}" >&2; \
+	loaded=0; failed=0; loaded_names=""; \
+	printf 'plugins:\n' >"$$cache_file"; \
+	for i in $$(seq 0 $$((plugin_count - 1))); do \
+		source_url=$$(yq -r ".plugins[$$i].source // \"\"" $(DEVRAIL_CONFIG)); \
+		if [ -z "$$source_url" ]; then \
+			echo "{\"level\":\"error\",\"msg\":\"plugin entry missing source field\",\"index\":$$i,\"language\":\"_plugins\",\"script\":\"_plugins-load\"}" >&2; \
+			failed=$$((failed + 1)); \
+			continue; \
+		fi; \
+		slug=$$(basename "$$source_url"); \
+		manifest="$$plugins_dir/$$slug/plugin.devrail.yml"; \
+		if [ ! -r "$$manifest" ]; then \
+			echo "{\"level\":\"error\",\"msg\":\"plugin manifest not found\",\"plugin\":\"$$slug\",\"path\":\"$$manifest\",\"language\":\"_plugins\",\"script\":\"_plugins-load\"}" >&2; \
+			failed=$$((failed + 1)); \
+			continue; \
+		fi; \
+		if bash /opt/devrail/scripts/plugin-validator.sh "$$manifest"; then \
+			loaded=$$((loaded + 1)); \
+			plugin_name=$$(yq -r '.name' "$$manifest"); \
+			plugin_version=$$(yq -r '.version' "$$manifest"); \
+			loaded_names="$${loaded_names}\"$$plugin_name\","; \
+			printf '  - name: %s\n    version: %s\n    source: %s\n    manifest: %s\n' \
+				"$$plugin_name" "$$plugin_version" "$$source_url" "$$manifest" >>"$$cache_file"; \
+		else \
+			failed=$$((failed + 1)); \
+		fi; \
+	done; \
+	echo "{\"level\":\"info\",\"msg\":\"plugin loader complete\",\"loaded\":$$loaded,\"failed\":$$failed,\"plugins\":[$${loaded_names%,}],\"language\":\"_plugins\",\"script\":\"_plugins-load\"}" >&2; \
+	if [ "$$failed" -gt 0 ]; then exit 2; fi
+
 # --- _lint: language-specific linting ---
-_lint: _check-config
+_lint: _plugins-load
 	@start_time=$$(date +%s%3N); \
 	overall_exit=0; \
 	ran_languages=""; \
@@ -394,7 +440,7 @@ _lint: _check-config
 	exit $$overall_exit
 
 # --- _format: language-specific format checking ---
-_format: _check-config
+_format: _plugins-load
 	@start_time=$$(date +%s%3N); \
 	overall_exit=0; \
 	ran_languages=""; \
@@ -544,7 +590,7 @@ _format: _check-config
 	exit $$overall_exit
 
 # --- _fix: language-specific format fixing (in-place) ---
-_fix: _check-config
+_fix: _plugins-load
 	@start_time=$$(date +%s%3N); \
 	overall_exit=0; \
 	ran_languages=""; \
@@ -694,7 +740,7 @@ _fix: _check-config
 	exit $$overall_exit
 
 # --- _test: language-specific test runners ---
-_test: _check-config
+_test: _plugins-load
 	@start_time=$$(date +%s%3N); \
 	overall_exit=0; \
 	ran_languages=""; \
@@ -875,7 +921,7 @@ _test: _check-config
 	exit $$overall_exit
 
 # --- _security: language-specific security scanners ---
-_security: _check-config
+_security: _plugins-load
 	@start_time=$$(date +%s%3N); \
 	overall_exit=0; \
 	ran_languages=""; \
@@ -1399,7 +1445,7 @@ _init: _check-config
 	echo "{\"target\":\"init\",\"created\":[$${created%,}],\"skipped\":[$${skipped%,}]}"
 
 # --- _check: orchestrate all targets ---
-_check: _check-config
+_check: _plugins-load
 	@overall_exit=0; \
 	overall_start=$$(date +%s%3N); \
 	results=""; \

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -31,6 +31,7 @@ DevRail has reached **v1.0** across all repositories. The core standards, toolch
 | **CI workflow templates** | Stable | GitHub Actions workflows and GitLab CI pipeline shipped in template repos. |
 | **Pre-commit hooks** | Stable | Conventional commit hook and per-language hooks configured in template repos. |
 | **Documentation site** | Stable | [devrail.dev](https://devrail.dev) is live with full standards coverage. |
+| **Plugin loader prelude** | Preview (v1.10.0+) | Validates `plugin.devrail.yml` manifests declared in `.devrail.yml` `plugins:` and runs as a prerequisite of every language target. No-op when `plugins:` is absent — v1.9.x behaviour unchanged. Resolver and execution loop ship in subsequent stories. |
 
 ## Consumer responsibilities
 

--- a/lib/version.sh
+++ b/lib/version.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# lib/version.sh — DevRail semver helpers
+#
+# Purpose: Provides semver comparison and image-version detection for the
+#          plugin loader and other version-aware code paths.
+# Usage:   source "${DEVRAIL_LIB}/version.sh"
+# Dependencies: lib/log.sh (must be sourced first)
+#
+# Functions:
+#   version_gte <a> <b>   - Returns 0 if dotted-numeric a >= b, 1 otherwise.
+#                           Recognises a "0.0.0-dev" or empty image version as
+#                           "unknown" and returns 0 (lenient for local dev).
+#   get_devrail_version   - Prints the running dev-toolchain image version.
+#                           Reads $DEVRAIL_VERSION first, then /opt/devrail/VERSION,
+#                           else prints "0.0.0-dev".
+
+# Guard against double-sourcing
+# shellcheck disable=SC2317
+if [[ -n "${_DEVRAIL_VERSION_LOADED:-}" ]]; then
+  return 0 2>/dev/null || true
+fi
+readonly _DEVRAIL_VERSION_LOADED=1
+
+# get_devrail_version prints the running dev-toolchain image version.
+# Resolution order:
+#   1. $DEVRAIL_VERSION env var (used by tests and CI overrides)
+#   2. /opt/devrail/VERSION file (written by Dockerfile from ARG DEVRAIL_VERSION)
+#   3. "0.0.0-dev" sentinel (treated as unknown by version_gte)
+get_devrail_version() {
+  if [[ -n "${DEVRAIL_VERSION:-}" ]]; then
+    printf "%s" "${DEVRAIL_VERSION}"
+    return 0
+  fi
+  if [[ -r /opt/devrail/VERSION ]]; then
+    tr -d '[:space:]' </opt/devrail/VERSION
+    return 0
+  fi
+  printf "0.0.0-dev"
+}
+
+# version_gte returns 0 if dotted-numeric "a" >= "b" semver-wise.
+# Special cases:
+#   - "0.0.0-dev" or empty `a` → returns 0 (lenient: dev/unknown image passes)
+#   - non-semver inputs → returns 1 (strict: bad data fails closed)
+# Compares MAJOR.MINOR.PATCH numerically; ignores any -prerelease/+build suffix on b.
+version_gte() {
+  local a="${1:-}"
+  local b="${2:-}"
+
+  # Lenient: an unknown/dev image version cannot meaningfully be compared
+  if [[ -z "${a}" || "${a}" == "0.0.0-dev" || "${a}" == "unknown" ]]; then
+    return 0
+  fi
+
+  # Strip any -prerelease or +build metadata from both sides for the compare
+  a="${a%%-*}"
+  a="${a%%+*}"
+  b="${b%%-*}"
+  b="${b%%+*}"
+
+  # Strict: both sides must be dotted-numeric MAJOR.MINOR.PATCH
+  local semver_re='^[0-9]+\.[0-9]+\.[0-9]+$'
+  if [[ ! "${a}" =~ ${semver_re} || ! "${b}" =~ ${semver_re} ]]; then
+    return 1
+  fi
+
+  local a_major a_minor a_patch b_major b_minor b_patch
+  IFS='.' read -r a_major a_minor a_patch <<<"${a}"
+  IFS='.' read -r b_major b_minor b_patch <<<"${b}"
+
+  if ((a_major != b_major)); then ((a_major > b_major)) && return 0 || return 1; fi
+  if ((a_minor != b_minor)); then ((a_minor > b_minor)) && return 0 || return 1; fi
+  if ((a_patch != b_patch)); then ((a_patch > b_patch)) && return 0 || return 1; fi
+  return 0
+}

--- a/scripts/plugin-validator.sh
+++ b/scripts/plugin-validator.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# scripts/plugin-validator.sh — Validate a DevRail plugin manifest
+#
+# Purpose: Parses a `plugin.devrail.yml` manifest with yq and validates it
+#          against the v1 plugin manifest schema (Story 13.2). Emits structured
+#          JSON error events for each violation. Reports ALL violations
+#          cumulatively (does NOT fail-fast on the first one).
+#
+# Usage:   bash scripts/plugin-validator.sh <manifest-path> [--help]
+#          Exit 0 — manifest is valid against schema_version: 1
+#          Exit 2 — one or more schema violations (misconfiguration)
+#          Exit 3 — manifest file not found / unreadable
+#
+# Dependencies: yq (v4+, in /usr/local/bin/yq), lib/log.sh, lib/platform.sh
+
+set -euo pipefail
+
+# --- Resolve library path ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEVRAIL_LIB="${DEVRAIL_LIB:-${SCRIPT_DIR}/../lib}"
+
+# shellcheck source=../lib/log.sh
+source "${DEVRAIL_LIB}/log.sh"
+# shellcheck source=../lib/platform.sh
+source "${DEVRAIL_LIB}/platform.sh"
+# shellcheck source=../lib/version.sh
+source "${DEVRAIL_LIB}/version.sh"
+
+# --- Help ---
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  log_info "plugin-validator.sh — Validate a DevRail plugin manifest"
+  log_info "Usage: bash scripts/plugin-validator.sh <manifest-path>"
+  log_info "Exit 0 — valid; 2 — schema violation; 3 — file not found"
+  exit 0
+fi
+
+# --- Args ---
+MANIFEST="${1:-}"
+if [[ -z "${MANIFEST}" ]]; then
+  log_error "manifest path argument required" "2"
+  log_error "usage: bash scripts/plugin-validator.sh <manifest-path>" "2"
+  exit 2
+fi
+
+if [[ ! -r "${MANIFEST}" ]]; then
+  log_error "manifest not found or unreadable: ${MANIFEST}" "3"
+  exit 3
+fi
+
+require_cmd "yq" "yq is required (apt install yq, or use the dev-toolchain image)"
+
+# --- Constants ---
+readonly EXPECTED_SCHEMA_VERSION=1
+readonly NAME_REGEX='^[a-z][a-z0-9_-]*$'
+readonly SEMVER_REGEX='^[0-9]+\.[0-9]+\.[0-9]+$'
+readonly VALID_TARGETS=(lint format_check format_fix fix test security)
+
+# --- State ---
+VIOLATIONS=0
+PLUGIN_NAME="unknown"
+
+# emit_violation outputs a structured JSON event for one schema violation.
+# Arguments: field, reason
+emit_violation() {
+  local field="$1"
+  local reason="$2"
+  local ts
+  ts="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+  printf '{"level":"error","msg":"plugin schema violation","plugin":"%s","field":"%s","reason":"%s","language":"_plugins","script":"plugin-validator.sh","ts":"%s"}\n' \
+    "${PLUGIN_NAME}" "${field}" "${reason}" "${ts}" >&2
+  VIOLATIONS=$((VIOLATIONS + 1))
+}
+
+# emit_info outputs a structured JSON event with `language: "_plugins"`.
+# Arguments: msg, [extra-key=value pairs as a single string]
+emit_info() {
+  local msg="$1"
+  local extra="${2:-}"
+  local ts
+  ts="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+  if [[ -n "${extra}" ]]; then
+    printf '{"level":"info","msg":"%s","plugin":"%s","language":"_plugins","script":"plugin-validator.sh","ts":"%s",%s}\n' \
+      "${msg}" "${PLUGIN_NAME}" "${ts}" "${extra}" >&2
+  else
+    printf '{"level":"info","msg":"%s","plugin":"%s","language":"_plugins","script":"plugin-validator.sh","ts":"%s"}\n' \
+      "${msg}" "${PLUGIN_NAME}" "${ts}" >&2
+  fi
+}
+
+# yq_field reads a scalar field; prints empty string when missing.
+yq_field() {
+  local field="$1"
+  yq -r ".${field} // \"\"" "${MANIFEST}" 2>/dev/null
+}
+
+# yq_type reports the !!type of a field; prints "missing" when absent.
+yq_type() {
+  local field="$1"
+  local result
+  result=$(yq -r ".${field} | type" "${MANIFEST}" 2>/dev/null || true)
+  if [[ -z "${result}" || "${result}" == "null" || "${result}" == "!!null" ]]; then
+    printf "missing"
+  else
+    printf "%s" "${result}"
+  fi
+}
+
+# --- Best-effort plugin name extraction (used in error events) ---
+_name_value="$(yq_field "name")"
+if [[ -n "${_name_value}" ]]; then
+  PLUGIN_NAME="${_name_value}"
+fi
+
+emit_info "validating manifest" "\"path\":\"${MANIFEST}\""
+
+# --- Validate schema_version ---
+sv_type="$(yq_type "schema_version")"
+if [[ "${sv_type}" == "missing" ]]; then
+  emit_violation "schema_version" "required field is missing"
+elif [[ "${sv_type}" != "!!int" ]]; then
+  emit_violation "schema_version" "must be an integer; got ${sv_type}"
+else
+  sv_value="$(yq -r '.schema_version' "${MANIFEST}")"
+  if [[ "${sv_value}" != "${EXPECTED_SCHEMA_VERSION}" ]]; then
+    emit_violation "schema_version" "unsupported version ${sv_value}; this loader supports schema_version: ${EXPECTED_SCHEMA_VERSION}"
+  fi
+fi
+
+# --- Validate name ---
+name_type="$(yq_type "name")"
+if [[ "${name_type}" == "missing" ]]; then
+  emit_violation "name" "required field is missing"
+elif [[ "${name_type}" != "!!str" ]]; then
+  emit_violation "name" "must be a string; got ${name_type}"
+else
+  name_value="$(yq -r '.name' "${MANIFEST}")"
+  if [[ ! "${name_value}" =~ ${NAME_REGEX} ]]; then
+    emit_violation "name" "value '${name_value}' does not match ${NAME_REGEX}"
+  fi
+fi
+
+# --- Validate version ---
+version_type="$(yq_type "version")"
+if [[ "${version_type}" == "missing" ]]; then
+  emit_violation "version" "required field is missing"
+elif [[ "${version_type}" != "!!str" ]]; then
+  emit_violation "version" "must be a string; got ${version_type}"
+else
+  version_value="$(yq -r '.version' "${MANIFEST}")"
+  if [[ ! "${version_value}" =~ ${SEMVER_REGEX} ]]; then
+    emit_violation "version" "value '${version_value}' is not a dotted-numeric semver (expected MAJOR.MINOR.PATCH)"
+  fi
+fi
+
+# --- Validate devrail_min_version ---
+mv_type="$(yq_type "devrail_min_version")"
+if [[ "${mv_type}" == "missing" ]]; then
+  emit_violation "devrail_min_version" "required field is missing"
+elif [[ "${mv_type}" != "!!str" ]]; then
+  emit_violation "devrail_min_version" "must be a string; got ${mv_type}"
+else
+  mv_value="$(yq -r '.devrail_min_version' "${MANIFEST}")"
+  if [[ ! "${mv_value}" =~ ${SEMVER_REGEX} ]]; then
+    emit_violation "devrail_min_version" "value '${mv_value}' is not a dotted-numeric semver (expected MAJOR.MINOR.PATCH)"
+  else
+    image_version="$(get_devrail_version)"
+    if ! version_gte "${image_version}" "${mv_value}"; then
+      emit_violation "devrail_min_version" "manifest requires ${mv_value} but this image is ${image_version}"
+    fi
+  fi
+fi
+
+# --- Validate targets ---
+targets_type="$(yq_type "targets")"
+if [[ "${targets_type}" == "missing" ]]; then
+  emit_violation "targets" "required field is missing"
+elif [[ "${targets_type}" != "!!map" ]]; then
+  emit_violation "targets" "must be a mapping; got ${targets_type}"
+else
+  declared_targets="$(yq -r '.targets | keys | .[]' "${MANIFEST}" 2>/dev/null || true)"
+  if [[ -z "${declared_targets}" ]]; then
+    emit_violation "targets" "must declare at least one of: ${VALID_TARGETS[*]}"
+  else
+    found_valid=0
+    while IFS= read -r target_name; do
+      [[ -z "${target_name}" ]] && continue
+      is_valid=0
+      for valid in "${VALID_TARGETS[@]}"; do
+        if [[ "${target_name}" == "${valid}" ]]; then
+          is_valid=1
+          found_valid=1
+          break
+        fi
+      done
+      if [[ "${is_valid}" -eq 0 ]]; then
+        emit_violation "targets.${target_name}" "unknown target '${target_name}' (valid: ${VALID_TARGETS[*]})"
+      else
+        # Each declared (valid) target needs a `cmd` string
+        cmd_type="$(yq_type "targets.${target_name}.cmd")"
+        if [[ "${cmd_type}" == "missing" ]]; then
+          emit_violation "targets.${target_name}.cmd" "required field is missing"
+        elif [[ "${cmd_type}" != "!!str" ]]; then
+          emit_violation "targets.${target_name}.cmd" "must be a string; got ${cmd_type}"
+        fi
+      fi
+    done <<<"${declared_targets}"
+    if [[ "${found_valid}" -eq 0 ]]; then
+      emit_violation "targets" "must declare at least one of: ${VALID_TARGETS[*]}"
+    fi
+  fi
+fi
+
+# --- Final outcome ---
+if [[ "${VIOLATIONS}" -gt 0 ]]; then
+  emit_info "manifest validation failed" "\"violations\":${VIOLATIONS}"
+  exit 2
+fi
+
+emit_info "manifest valid" "\"schema_version\":${EXPECTED_SCHEMA_VERSION}"
+exit 0

--- a/tests/fixtures/plugins/bad-name/plugin.devrail.yml
+++ b/tests/fixtures/plugins/bad-name/plugin.devrail.yml
@@ -1,0 +1,7 @@
+schema_version: 1
+name: Elixir
+version: 1.0.0
+devrail_min_version: 1.10.0
+targets:
+  lint:
+    cmd: "true"

--- a/tests/fixtures/plugins/incompatible-version/plugin.devrail.yml
+++ b/tests/fixtures/plugins/incompatible-version/plugin.devrail.yml
@@ -1,0 +1,7 @@
+schema_version: 1
+name: future-plugin
+version: 1.0.0
+devrail_min_version: 99.0.0
+targets:
+  lint:
+    cmd: "true"

--- a/tests/fixtures/plugins/invalid-schema/plugin.devrail.yml
+++ b/tests/fixtures/plugins/invalid-schema/plugin.devrail.yml
@@ -1,0 +1,7 @@
+schema_version: 2
+name: elixir
+version: 1.0.0
+devrail_min_version: 1.10.0
+targets:
+  lint:
+    cmd: "true"

--- a/tests/fixtures/plugins/missing-field/plugin.devrail.yml
+++ b/tests/fixtures/plugins/missing-field/plugin.devrail.yml
@@ -1,0 +1,5 @@
+schema_version: 1
+name: incomplete
+version: 1.0.0
+devrail_min_version: 1.10.0
+# `targets:` intentionally omitted to exercise the missing-required-field path.

--- a/tests/fixtures/plugins/valid-elixir/plugin.devrail.yml
+++ b/tests/fixtures/plugins/valid-elixir/plugin.devrail.yml
@@ -1,0 +1,17 @@
+schema_version: 1
+name: elixir
+version: 1.0.0
+description: "Elixir language support — Story 13.2 happy-path fixture"
+devrail_min_version: 1.10.0
+
+targets:
+  lint:
+    cmd: "mix credo --strict {paths}"
+  format_check:
+    cmd: "mix format --check-formatted"
+  test:
+    cmd: "mix test"
+
+gates:
+  lint: ["mix.exs"]
+  test: ["mix.exs", "test/"]

--- a/tests/test-plugin-loader.sh
+++ b/tests/test-plugin-loader.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# tests/test-plugin-loader.sh — Validate the plugin manifest parser + loader (Story 13.2)
+#
+# Verifies, against checked-in fixtures under tests/fixtures/plugins/:
+#   1. The validator accepts a valid v1 manifest.
+#   2. Each negative fixture (invalid-schema, incompatible-version, bad-name,
+#      missing-field) is rejected with the expected JSON event.
+#   3. The Makefile loader (`_plugins-load`) is a no-op when .devrail.yml has
+#      no `plugins:` section — regression safety for v1.9.x consumers.
+#   4. The Makefile loader exits 2 when any declared plugin's manifest fails.
+#   5. The Makefile loader writes a parsed cache when all manifests pass.
+#
+# Usage: bash tests/test-plugin-loader.sh
+# Env:
+#   DEVRAIL_IMAGE  override image name (default: ghcr.io/devrail-dev/dev-toolchain)
+#   DEVRAIL_TAG    override image tag  (default: local)
+
+set -euo pipefail
+
+IMAGE="${DEVRAIL_IMAGE:-ghcr.io/devrail-dev/dev-toolchain}:${DEVRAIL_TAG:-local}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURE_BASE="${REPO_ROOT}/tests/fixtures/plugins"
+WORKDIR="$(mktemp -d)"
+
+cleanup() {
+  if [ -n "${WORKDIR:-}" ] && [ -d "$WORKDIR" ]; then
+    docker run --rm -v "$WORKDIR:/cleanup" "$IMAGE" \
+      sh -c 'rm -rf /cleanup/* /cleanup/.[!.]* 2>/dev/null || true' >/dev/null 2>&1 || true
+    rmdir "$WORKDIR" 2>/dev/null || rm -rf "$WORKDIR" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+# run_validator FIXTURE_NAME -> stderr from the validator, with exit code captured
+run_validator() {
+  local fixture="$1"
+  docker run --rm \
+    -v "$FIXTURE_BASE:/fixtures:ro" \
+    -e DEVRAIL_VERSION="${DEVRAIL_VERSION_OVERRIDE:-1.10.0}" \
+    "$IMAGE" \
+    bash /opt/devrail/scripts/plugin-validator.sh "/fixtures/$fixture/plugin.devrail.yml" \
+    2>&1
+}
+
+# assert_eq EXPECTED ACTUAL CONTEXT
+assert_eq() {
+  local expected="$1" actual="$2" context="$3"
+  if [ "$expected" != "$actual" ]; then
+    echo "FAIL [$context]: expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+# assert_jq EVENTS-FILE JQ-FILTER CONTEXT
+assert_jq() {
+  local events="$1" filter="$2" context="$3"
+  if ! grep -E '^\{' "$events" | jq -e "$filter" >/dev/null 2>&1; then
+    echo "FAIL [$context]: jq filter '$filter' did not match any event in:" >&2
+    grep -E '^\{' "$events" | jq -c . >&2 2>/dev/null || cat "$events" >&2
+    exit 1
+  fi
+}
+
+# --- Unit-level: the validator alone, against each fixture -----------------
+
+echo "==> Unit: valid-elixir → exit 0, 'manifest valid' info event"
+out="$(run_validator valid-elixir)" && exit_code=0 || exit_code=$?
+assert_eq "0" "$exit_code" "valid-elixir exit code"
+echo "$out" >"$WORKDIR/valid.events"
+assert_jq "$WORKDIR/valid.events" 'select(.level=="info" and .msg=="manifest valid" and .plugin=="elixir")' "valid-elixir manifest valid event"
+
+echo "==> Unit: invalid-schema → exit 2, schema_version violation"
+out="$(run_validator invalid-schema)" && exit_code=0 || exit_code=$?
+assert_eq "2" "$exit_code" "invalid-schema exit code"
+echo "$out" >"$WORKDIR/invalid-schema.events"
+assert_jq "$WORKDIR/invalid-schema.events" 'select(.level=="error" and .field=="schema_version" and (.reason | contains("unsupported version 2")))' "invalid-schema violation event"
+
+echo "==> Unit: incompatible-version → exit 2, devrail_min_version violation"
+out="$(run_validator incompatible-version)" && exit_code=0 || exit_code=$?
+assert_eq "2" "$exit_code" "incompatible-version exit code"
+echo "$out" >"$WORKDIR/incompatible-version.events"
+assert_jq "$WORKDIR/incompatible-version.events" 'select(.level=="error" and .field=="devrail_min_version" and (.reason | contains("requires 99.0.0")))' "incompatible-version violation event"
+
+echo "==> Unit: bad-name → exit 2, name regex violation"
+out="$(run_validator bad-name)" && exit_code=0 || exit_code=$?
+assert_eq "2" "$exit_code" "bad-name exit code"
+echo "$out" >"$WORKDIR/bad-name.events"
+assert_jq "$WORKDIR/bad-name.events" 'select(.level=="error" and .field=="name" and (.reason | contains("does not match")))' "bad-name violation event"
+
+echo "==> Unit: missing-field (no targets) → exit 2, targets violation"
+out="$(run_validator missing-field)" && exit_code=0 || exit_code=$?
+assert_eq "2" "$exit_code" "missing-field exit code"
+echo "$out" >"$WORKDIR/missing-field.events"
+assert_jq "$WORKDIR/missing-field.events" 'select(.level=="error" and .field=="targets" and (.reason | contains("required field is missing")))' "missing-field violation event"
+
+# --- Integration: full _plugins-load loader against synthetic .devrail.yml --
+
+echo "==> Integration: no plugins section → loader exits 0 with 'no plugins' event"
+mkdir -p "$WORKDIR/no-plugins"
+cat >"$WORKDIR/no-plugins/.devrail.yml" <<'YAML'
+languages: [bash]
+YAML
+out="$(docker run --rm \
+  -v "$WORKDIR/no-plugins:/workspace" \
+  -v "$REPO_ROOT/Makefile:/workspace/Makefile:ro" \
+  -w /workspace \
+  "$IMAGE" \
+  make _plugins-load 2>&1)" && exit_code=0 || exit_code=$?
+assert_eq "0" "$exit_code" "no-plugins-section exit code"
+echo "$out" >"$WORKDIR/no-plugins.events"
+assert_jq "$WORKDIR/no-plugins.events" 'select(.msg=="no plugins declared")' "no-plugins-declared event"
+
+echo "==> Integration: valid plugin → loader exits 0, writes cache, emits summary"
+mkdir -p "$WORKDIR/with-valid"
+cat >"$WORKDIR/with-valid/.devrail.yml" <<'YAML'
+languages: [elixir]
+plugins:
+  - source: github.com/community/valid-elixir
+    rev: v1.0.0
+    languages: [elixir]
+YAML
+out="$(docker run --rm \
+  -v "$WORKDIR/with-valid:/workspace" \
+  -v "$REPO_ROOT/Makefile:/workspace/Makefile:ro" \
+  -v "$FIXTURE_BASE:/opt/devrail/plugins:ro" \
+  -e DEVRAIL_VERSION=1.10.0 \
+  -w /workspace \
+  "$IMAGE" \
+  make _plugins-load 2>&1)" && exit_code=0 || exit_code=$?
+assert_eq "0" "$exit_code" "valid-plugin exit code"
+echo "$out" >"$WORKDIR/with-valid.events"
+assert_jq "$WORKDIR/with-valid.events" 'select(.msg=="plugin loader complete" and .loaded==1 and .failed==0)' "valid-plugin loader-complete event"
+
+echo "==> Integration: invalid plugin → loader exits 2 with failed counter"
+mkdir -p "$WORKDIR/with-invalid"
+cat >"$WORKDIR/with-invalid/.devrail.yml" <<'YAML'
+languages: [bad-name]
+plugins:
+  - source: github.com/community/bad-name
+    rev: v1.0.0
+    languages: [bad-name]
+YAML
+out="$(docker run --rm \
+  -v "$WORKDIR/with-invalid:/workspace" \
+  -v "$REPO_ROOT/Makefile:/workspace/Makefile:ro" \
+  -v "$FIXTURE_BASE:/opt/devrail/plugins:ro" \
+  -e DEVRAIL_VERSION=1.10.0 \
+  -w /workspace \
+  "$IMAGE" \
+  make _plugins-load 2>&1)" && exit_code=0 || exit_code=$?
+assert_eq "2" "$exit_code" "invalid-plugin exit code"
+echo "$out" >"$WORKDIR/with-invalid.events"
+assert_jq "$WORKDIR/with-invalid.events" 'select(.msg=="plugin loader complete" and .failed >= 1)' "invalid-plugin failure-summary event"
+
+echo "==> All plugin-loader smoke checks passed"


### PR DESCRIPTION
## Summary

Foundation work for the **v1.10.0 plugin architecture** (Epic 13). Adds the plugin manifest schema validator and the `_plugins-load` Makefile prelude that runs before any language-touching target.

**No behaviour change for v1.9.x consumers** — the loader is a no-op when `.devrail.yml` has no `plugins:` section (just emits a single info event and exits 0).

This is the parser/loader. The companion stories ship the resolver (13.3), build pipeline (13.4), execution loop (13.5), and v1.10.0 release (13.6).

## What's in the PR

### `scripts/plugin-validator.sh`
Validates a `plugin.devrail.yml` against `schema_version: 1`. Cumulative — emits one `error`-level JSON event per violation, doesn't fail-fast on the first. Validates:

- Required fields: `schema_version`, `name`, `version`, `devrail_min_version`, `targets`
- Type checks via `yq -r '.field | type'`
- `name` matches `^[a-z][a-z0-9_-]*$`
- `version` and `devrail_min_version` are dotted-numeric semver
- `devrail_min_version` <= running image version (via `lib/version.sh`)
- `targets` declares at least one of `lint`/`format_check`/`format_fix`/`fix`/`test`/`security`, each with a string `cmd`

Exits: `0` valid, `2` schema violation, `3` manifest unreadable.

### `lib/version.sh`
- `version_gte <a> <b>` — pure-bash dotted-numeric semver compare. Lenient on `0.0.0-dev` / empty / `unknown` (returns 0 — local-dev images don't enforce).
- `get_devrail_version` — reads `$DEVRAIL_VERSION` env, then `/opt/devrail/VERSION`, else `0.0.0-dev`.

### Makefile `_plugins-load`
New internal target wired as a prerequisite of `_check`, `_lint`, `_format`, `_fix`, `_test`, `_security`. Reads `.devrail.yml` `plugins:`, locates each manifest under `${DEVRAIL_PLUGINS_DIR:-/opt/devrail/plugins}/<slug>/plugin.devrail.yml`, validates each, writes a parsed cache to `${DEVRAIL_PLUGINS_CACHE:-/tmp/devrail-plugins-loaded.yaml}` for Story 13.5's execution loop, exits `2` on any failure.

### Dockerfile
- `ARG DEVRAIL_VERSION=0.0.0-dev` → `/opt/devrail/VERSION` and `LABEL org.opencontainers.image.version`
- CI/release passes `--build-arg DEVRAIL_VERSION=$(git describe ...)` for production tagging

### Tests
- 5 fixture manifests (`tests/fixtures/plugins/{valid-elixir,invalid-schema,incompatible-version,bad-name,missing-field}/plugin.devrail.yml`)
- `tests/test-plugin-loader.sh` — 5 validator unit cases + 3 loader integration cases (no plugins / valid plugin / invalid plugin)
- Wired into `.github/workflows/ci.yml` after the Rails smoke step

## Acceptance criteria from story 13.2

- [x] AC 1 — `_plugins-load` runs before `_lint`/`_format`/`_fix`/`_test`/`_security`/`_check`; manifests are parsed by `yq` and validated against `schema_version: 1`
- [x] AC 2 — unsupported `schema_version` produces a structured error event and exits `2`
- [x] AC 3 — `devrail_min_version` greater than image version produces a structured error event and exits `2`
- [x] AC 4 — missing required fields and constraint violations produce per-violation error events and exit `2`
- [x] AC 5 — successful loader emits a summary `info` event and writes a parsed cache for downstream targets
- [x] AC 6 — no `plugins:` section emits "no plugins declared" info and exits `0`; v1.9.x behaviour unchanged
- [x] AC 7 — `tests/test-plugin-loader.sh` covers all six cases via `jq`-based event assertions

## Test plan

- [x] Local image rebuilds cleanly (~5m full, ~3m cached)
- [x] `tests/test-plugin-loader.sh` — 8/8 checks pass
- [x] `tests/smoke-rails.sh` — regression-safe (still passes)
- [x] `make _check` on dev-toolchain itself — pass with `"no plugins declared"` info event
- [ ] CI green on this PR (build + scan + Rails smoke + plugin loader smoke)

## Out of scope (next stories)

- **Story 13.3** — fetcher + lockfile (resolves `rev:` to deterministic local paths)
- **Story 13.4** — extended-image build pipeline
- **Story 13.5** — execution loop (runs plugin commands during `_lint` etc.)
- **Story 13.6** — v1.10.0 release with all of the above

🤖 Generated with [Claude Code](https://claude.com/claude-code)