### PR TITLE
feat(makefile): plugin resolver and lockfile (Story 13.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,18 @@ jobs:
           DEVRAIL_IMAGE: ${{ env.IMAGE_NAME }}
           DEVRAIL_TAG: ${{ env.IMAGE_TAG }}
 
+      # Phase 2e: Plugin resolver + lockfile smoke test (Story 13.3)
+      # Drives `make plugins-update` against a local-filesystem git fixture
+      # (no network) covering: SHA passthrough, tag→SHA, branch rejection,
+      # lockfile determinism, idempotent fetch, lockfile mismatch, tampering
+      # detection, missing lockfile, no-plugins regression, unreachable
+      # source, atomic-lockfile-on-failure.
+      - name: Plugin resolver smoke test
+        run: bash tests/test-plugin-resolver.sh
+        env:
+          DEVRAIL_IMAGE: ${{ env.IMAGE_NAME }}
+          DEVRAIL_TAG: ${{ env.IMAGE_TAG }}
+
       # Phase 3: Security scans
       # Blocking scan: OS packages only. We control the base image and can act on
       # these. ignore-unfixed skips CVEs with no Debian patch available yet.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Plugin resolver and lockfile (Story 13.3, Epic 13 / v1.10.x preview).
+  - **`make plugins-update`** — public target that resolves every
+    `.devrail.yml` plugin's `rev:` to an immutable SHA via `git ls-remote`,
+    fetches the plugin tree to
+    `${DEVRAIL_PLUGINS_DIR:-/opt/devrail/plugins}/<source-slug>/<rev>/`
+    (the same path the Story 13.2 loader reads), computes a deterministic
+    `content_hash`, and writes `.devrail.lock` atomically. Branch refs are
+    rejected with a clear error; only tags and 40-char SHAs accepted.
+  - **`.devrail.lock`** — checked into VCS by consumers, like `Gemfile.lock`
+    or `Cargo.lock`. Records `source`, `rev`, resolved `sha`, manifest
+    `schema_version`, and `content_hash` per plugin. Sorted alphabetically
+    by `source` for deterministic diffs.
+  - **`_plugins-verify`** — new internal Make target that runs as a
+    prerequisite of `_plugins-load` on every `make check`. Confirms every
+    `.devrail.yml` plugin entry has a matching lockfile entry with the
+    same rev, and re-computes `content_hash` of each cached tree to detect
+    tag-rebase tampering. Fails with code 2 on any disagreement; emits
+    structured error events with remediation hints
+    (`"run \`make plugins-update\`"`).
+  - Fully no-op when `.devrail.yml` declares no `plugins:` (regression-safe
+    for v1.9.x and v1.10.x consumers without plugin declarations).
+- `scripts/plugin-resolver.sh` and `scripts/plugin-lockfile-verify.sh` —
+  pure-bash, yq + git + sha256sum dependencies (all in image).
+- `tests/fixtures/plugin-repos/elixir-v1/` and `elixir-v1-tampered/` —
+  fixture trees (no `.git/`); the test harness initialises git per case.
+- `tests/test-plugin-resolver.sh` — 11-case smoke covering SHA passthrough,
+  tag→SHA resolution, branch rejection, lockfile determinism, idempotent
+  fetch, lockfile mismatch, tampering detection, missing lockfile,
+  no-plugins regression, unreachable source, and atomic-lockfile-on-failure.
+  Wired into `.github/workflows/ci.yml`.
+
 ## [1.10.1] - 2026-05-03
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,8 @@ DOCKER_RUN := docker run --rm \
 # ---------------------------------------------------------------------------
 # .PHONY declarations
 # ---------------------------------------------------------------------------
-.PHONY: help build lint format fix test security scan docs changelog check install-hooks init release
-.PHONY: _lint _format _fix _test _security _scan _docs _changelog _check _check-config _init
+.PHONY: help build lint format fix test security scan docs changelog check install-hooks init release plugins-update
+.PHONY: _lint _format _fix _test _security _scan _docs _changelog _check _check-config _init _plugins-update _plugins-verify
 
 # ===========================================================================
 # Public targets (run on host, delegate to Docker container)
@@ -137,6 +137,9 @@ init: ## Scaffold config files for declared languages
 lint: ## Run all linters
 	$(DOCKER_RUN) make _lint
 
+plugins-update: ## Resolve plugin refs and write .devrail.lock
+	$(DOCKER_RUN) make _plugins-update
+
 release: ## Cut a versioned release (usage: make release VERSION=1.6.0)
 	@if [ -z "$(VERSION)" ]; then \
 		echo "Error: VERSION is required. Usage: make release VERSION=1.6.0"; \
@@ -176,6 +179,23 @@ _check-config:
 		exit 2; \
 	fi
 
+# --- _plugins-update: resolve plugin refs and write .devrail.lock ---
+# Story 13.3: invoked by `make plugins-update`. Reads `.devrail.yml`,
+# resolves each `rev:` to an immutable SHA via `git ls-remote`, fetches the
+# plugin tree to the rev-aware cache path, computes content_hash, and writes
+# `.devrail.lock` atomically. No-op when no plugins are declared.
+_plugins-update: _check-config
+	@bash /opt/devrail/scripts/plugin-resolver.sh $(DEVRAIL_CONFIG)
+
+# --- _plugins-verify: lockfile-vs-config consistency check ---
+# Story 13.3: prerequisite of _plugins-load on every `make check`. Confirms
+# every `.devrail.yml` plugin entry has a matching `.devrail.lock` entry with
+# the same rev, and re-computes content_hash on the cached tree to detect
+# tag-rebase tampering. No-op when no plugins are declared (regression-safe
+# for v1.9.x consumers without `plugins:` in `.devrail.yml`).
+_plugins-verify: _check-config
+	@bash /opt/devrail/scripts/plugin-lockfile-verify.sh $(DEVRAIL_CONFIG)
+
 # --- _plugins-load: validate every plugin manifest declared in .devrail.yml ---
 # Story 13.2: runs as a prerequisite of every language-touching target. Exits 2
 # (misconfig) if any manifest is invalid, so no tool runs against a broken
@@ -190,7 +210,7 @@ _check-config:
 # so Story 13.5's execution loop can consume `.targets[]`, `.gates[]`, etc.
 # without re-reading the manifest from disk.
 .PHONY: _plugins-load
-_plugins-load: _check-config
+_plugins-load: _plugins-verify
 	@plugins_dir="$${DEVRAIL_PLUGINS_DIR:-/opt/devrail/plugins}"; \
 	cache_file="$${DEVRAIL_PLUGINS_CACHE:-/tmp/devrail-plugins-loaded.yaml}"; \
 	plugin_count=$$(yq -r '.plugins // [] | length' $(DEVRAIL_CONFIG) 2>/dev/null || echo 0); \

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -31,7 +31,7 @@ DevRail has reached **v1.0** across all repositories. The core standards, toolch
 | **CI workflow templates** | Stable | GitHub Actions workflows and GitLab CI pipeline shipped in template repos. |
 | **Pre-commit hooks** | Stable | Conventional commit hook and per-language hooks configured in template repos. |
 | **Documentation site** | Stable | [devrail.dev](https://devrail.dev) is live with full standards coverage. |
-| **Plugin loader prelude** | Preview (v1.10.0+) | Validates `plugin.devrail.yml` manifests declared in `.devrail.yml` `plugins:` and runs as a prerequisite of every language target. No-op when `plugins:` is absent — v1.9.x behaviour unchanged. Resolver and execution loop ship in subsequent stories. |
+| **Plugin loader + resolver + lockfile** | Preview (v1.10.x) | Validates `plugin.devrail.yml` manifests, resolves `rev:` to immutable SHAs via `make plugins-update`, records reproducibility metadata in `.devrail.lock`. Verifies lockfile + content_hash on every `make check`. No-op when `plugins:` is absent — v1.9.x behaviour unchanged. Execution loop ships in Story 13.5. |
 
 ## Consumer responsibilities
 

--- a/scripts/plugin-lockfile-verify.sh
+++ b/scripts/plugin-lockfile-verify.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# scripts/plugin-lockfile-verify.sh — Verify .devrail.lock matches .devrail.yml
+#
+# Purpose: Fast verification — runs as a `_plugins-load` prerequisite on every
+#          `make check` invocation. Compares each `.devrail.yml` `plugins:`
+#          entry against `.devrail.lock`, then re-computes content_hash for
+#          each cached tree and compares to the lockfile-recorded hash.
+#
+# Usage:   bash scripts/plugin-lockfile-verify.sh [<devrail-yml-path>] [--help]
+#          Exit 0 — verified or no-op (no plugins declared)
+#          Exit 2 — disagreement, missing lockfile, or tampering detected
+#
+# Dependencies: yq v4+, sha256sum, find, sort, lib/log.sh
+
+set -euo pipefail
+LC_ALL=C
+export LC_ALL
+
+# --- Resolve library path ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEVRAIL_LIB="${DEVRAIL_LIB:-${SCRIPT_DIR}/../lib}"
+
+# shellcheck source=../lib/log.sh
+source "${DEVRAIL_LIB}/log.sh"
+
+# --- Help ---
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  log_info "plugin-lockfile-verify.sh — Verify .devrail.lock matches .devrail.yml"
+  log_info "Usage: bash scripts/plugin-lockfile-verify.sh [<devrail-yml-path>]"
+  log_info "Exit 0 — verified; 2 — mismatch / missing lockfile / tampered cache"
+  exit 0
+fi
+
+# --- Args ---
+DEVRAIL_YML="${1:-.devrail.yml}"
+PLUGINS_DIR="${DEVRAIL_PLUGINS_DIR:-/opt/devrail/plugins}"
+LOCKFILE="$(dirname "${DEVRAIL_YML}")/.devrail.lock"
+
+if [[ ! -r "${DEVRAIL_YML}" ]]; then
+  log_event error "config not readable" path="${DEVRAIL_YML}" language=_plugins
+  exit 2
+fi
+
+require_cmd "yq" "yq is required (v4+)"
+
+# --- No-op when no plugins declared (regression-safe for v1.9.x consumers) ---
+plugin_count="$(yq -r '.plugins // [] | length' "${DEVRAIL_YML}" 2>/dev/null || echo 0)"
+if [[ "${plugin_count}" == "0" ]]; then
+  # Even if .devrail.lock exists, having no plugins declared means there is
+  # nothing for the loader to load. Quietly succeed.
+  exit 0
+fi
+
+# --- Lockfile must exist when plugins are declared ---
+if [[ ! -r "${LOCKFILE}" ]]; then
+  log_event error "lockfile missing" \
+    path="${LOCKFILE}" \
+    reason="run \`make plugins-update\` to generate .devrail.lock" \
+    language=_plugins
+  exit 2
+fi
+
+require_cmd "sha256sum" "sha256sum is required (coreutils)"
+
+# compute_content_hash <dir>
+compute_content_hash() {
+  local dir="$1"
+  (cd "${dir}" && find . -type f \
+    -not -path './.git/*' \
+    -not -name '.devrail.sha' \
+    -print0 |
+    sort -z |
+    xargs -0 sha256sum |
+    sha256sum |
+    cut -d' ' -f1)
+}
+
+# --- Cross-check every yml entry has a matching lock entry with same rev ---
+violations=0
+for i in $(seq 0 $((plugin_count - 1))); do
+  yml_source="$(yq -r ".plugins[${i}].source // \"\"" "${DEVRAIL_YML}")"
+  yml_rev="$(yq -r ".plugins[${i}].rev // \"\"" "${DEVRAIL_YML}")"
+  if [[ -z "${yml_source}" || -z "${yml_rev}" ]]; then
+    log_event error "plugin entry missing source or rev" \
+      index:="${i}" source="${yml_source}" rev="${yml_rev}" language=_plugins
+    violations=$((violations + 1))
+    continue
+  fi
+
+  lock_rev="$(yq -r ".plugins[] | select(.source == \"${yml_source}\") | .rev" "${LOCKFILE}" 2>/dev/null | head -1)"
+  if [[ -z "${lock_rev}" || "${lock_rev}" == "null" ]]; then
+    log_event error "lockfile mismatch" \
+      source="${yml_source}" \
+      reason="no entry in .devrail.lock; run \`make plugins-update\`" \
+      language=_plugins
+    violations=$((violations + 1))
+    continue
+  fi
+  if [[ "${lock_rev}" != "${yml_rev}" ]]; then
+    log_event error "lockfile mismatch" \
+      source="${yml_source}" \
+      yml_rev="${yml_rev}" lock_rev="${lock_rev}" \
+      reason="rev disagreement; run \`make plugins-update\`" \
+      language=_plugins
+    violations=$((violations + 1))
+    continue
+  fi
+
+  # Content-hash tampering check: re-compute hash of cached tree, compare
+  # to the lockfile-recorded hash.
+  recorded_hash="$(yq -r ".plugins[] | select(.source == \"${yml_source}\") | .content_hash" "${LOCKFILE}" 2>/dev/null | head -1)"
+  recorded_hash="${recorded_hash#sha256:}"
+
+  slug="$(basename "${yml_source}")"
+  cached_dir="${PLUGINS_DIR}/${slug}/${yml_rev}"
+  if [[ ! -d "${cached_dir}" ]]; then
+    log_event error "cached tree missing" \
+      source="${yml_source}" rev="${yml_rev}" path="${cached_dir}" \
+      reason="run \`make plugins-update\` to repopulate the cache" \
+      language=_plugins
+    violations=$((violations + 1))
+    continue
+  fi
+
+  actual_hash="$(compute_content_hash "${cached_dir}")"
+  if [[ "${actual_hash}" != "${recorded_hash}" ]]; then
+    log_event error "content_hash mismatch (tampering or stale cache)" \
+      source="${yml_source}" rev="${yml_rev}" \
+      recorded="sha256:${recorded_hash}" actual="sha256:${actual_hash}" \
+      reason="cached tree differs from lockfile; run \`make plugins-update\`" \
+      language=_plugins
+    violations=$((violations + 1))
+    continue
+  fi
+done
+
+if [[ "${violations}" -gt 0 ]]; then
+  log_event error "lockfile verification failed" violations:="${violations}" language=_plugins
+  exit 2
+fi
+
+log_event info "lockfile verified" plugins:="${plugin_count}" language=_plugins
+exit 0

--- a/scripts/plugin-resolver.sh
+++ b/scripts/plugin-resolver.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# scripts/plugin-resolver.sh — Resolve plugin refs and write .devrail.lock
+#
+# Purpose: For each plugin declared in `.devrail.yml`, resolve the `rev:`
+#          (tag or SHA) to an immutable SHA via `git ls-remote`, fetch the
+#          plugin repo to a content-addressed cache directory, compute a
+#          deterministic content_hash of the tree, and write a sorted YAML
+#          lockfile atomically.
+#
+# Usage:   bash scripts/plugin-resolver.sh [<devrail-yml-path>] [--help]
+#          Default config path: .devrail.yml in CWD.
+#          Exit 0 — lockfile written (or no-op if no plugins declared)
+#          Exit 2 — resolution / fetch / configuration failure
+#
+# Dependencies: yq v4+, git 2+, sha256sum, find, sort, lib/log.sh,
+#               lib/version.sh
+
+set -euo pipefail
+LC_ALL=C
+export LC_ALL
+
+# --- Resolve library path ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEVRAIL_LIB="${DEVRAIL_LIB:-${SCRIPT_DIR}/../lib}"
+
+# shellcheck source=../lib/log.sh
+source "${DEVRAIL_LIB}/log.sh"
+# shellcheck source=../lib/version.sh
+source "${DEVRAIL_LIB}/version.sh"
+
+# --- Help ---
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  log_info "plugin-resolver.sh — Resolve plugin refs and write .devrail.lock"
+  log_info "Usage: bash scripts/plugin-resolver.sh [<devrail-yml-path>]"
+  log_info "Default config: .devrail.yml; default plugins dir: \$DEVRAIL_PLUGINS_DIR"
+  log_info "Exit 0 — success or no-op; 2 — resolution/fetch failure"
+  exit 0
+fi
+
+# --- Constants ---
+readonly LOCKFILE_SCHEMA_VERSION=1
+readonly SHA_REGEX='^[a-f0-9]{40}$'
+
+# --- Args ---
+DEVRAIL_YML="${1:-.devrail.yml}"
+PLUGINS_DIR="${DEVRAIL_PLUGINS_DIR:-/opt/devrail/plugins}"
+LOCKFILE="$(dirname "${DEVRAIL_YML}")/.devrail.lock"
+LOCKFILE_TMP="${LOCKFILE}.tmp.$$"
+
+if [[ ! -r "${DEVRAIL_YML}" ]]; then
+  log_event error "config not readable" path="${DEVRAIL_YML}" language=_plugins
+  exit 2
+fi
+
+require_cmd "yq" "yq is required (v4+)"
+require_cmd "git" "git is required"
+require_cmd "sha256sum" "sha256sum is required (coreutils)"
+
+# Always remove the temp lockfile on exit (atomic-write contract).
+trap 'rm -f "${LOCKFILE_TMP}"' EXIT
+
+# resolve_ref <source-url> <rev>
+# Echoes the resolved SHA on stdout.
+# Rejects branch refs and unrecognised refs with a non-zero return.
+resolve_ref() {
+  local source_url="$1"
+  local rev="$2"
+
+  # Branch detection — if the rev matches a remote head, reject.
+  local heads_match
+  heads_match="$(git -c protocol.file.allow=always ls-remote --heads "${source_url}" "${rev}" 2>/dev/null || true)"
+  if [[ -n "${heads_match}" ]]; then
+    log_event error "branch refs are not allowed" \
+      source="${source_url}" rev="${rev}" \
+      reason="pin a tag or 40-char SHA, not a branch" \
+      language=_plugins
+    return 1
+  fi
+
+  # SHA passthrough: if rev looks like a 40-char hex, accept it directly.
+  if [[ "${rev}" =~ ${SHA_REGEX} ]]; then
+    printf "%s" "${rev}"
+    return 0
+  fi
+
+  # Tag resolution. Prefer the dereferenced (peeled) tag entry "<sha> refs/tags/<tag>^{}"
+  # for annotated tags; fall back to the lightweight tag entry.
+  local refs sha=""
+  refs="$(git -c protocol.file.allow=always ls-remote --tags "${source_url}" "${rev}" 2>/dev/null || true)"
+  if [[ -z "${refs}" ]]; then
+    log_event error "ref not found at source" \
+      source="${source_url}" rev="${rev}" \
+      reason="not a tag, branch, or recognisable SHA at the given source" \
+      language=_plugins
+    return 1
+  fi
+  # Look for peeled annotated form first (suffix ^{})
+  sha="$(printf '%s\n' "${refs}" | awk '$2 ~ /\^\{\}$/ {print $1; exit}')"
+  if [[ -z "${sha}" ]]; then
+    sha="$(printf '%s\n' "${refs}" | awk 'NR==1 {print $1}')"
+  fi
+  if [[ ! "${sha}" =~ ${SHA_REGEX} ]]; then
+    log_event error "ref resolution produced invalid SHA" \
+      source="${source_url}" rev="${rev}" got="${sha}" \
+      language=_plugins
+    return 1
+  fi
+  printf "%s" "${sha}"
+}
+
+# fetch_to_cache <source-url> <slug> <rev>
+# Clones the source at <sha> into ${PLUGINS_DIR}/<slug>/<rev>/ if not already
+# present. Idempotent — if the cached tree exists, no fetch occurs.
+fetch_to_cache() {
+  local source_url="$1"
+  local slug="$2"
+  local rev="$3"
+  local sha="$4"
+  local target="${PLUGINS_DIR}/${slug}/${rev}"
+
+  if [[ -f "${target}/plugin.devrail.yml" && -f "${target}/.devrail.sha" ]]; then
+    local existing
+    existing="$(cat "${target}/.devrail.sha")"
+    if [[ "${existing}" == "${sha}" ]]; then
+      log_event info "plugin already cached" slug="${slug}" rev="${rev}" sha="${sha}" language=_plugins
+      return 0
+    fi
+  fi
+
+  log_event info "fetching plugin" source="${source_url}" rev="${rev}" sha="${sha}" language=_plugins
+
+  mkdir -p "${target}"
+  local fetch_dir
+  fetch_dir="$(mktemp -d "${target}.fetch.XXXXXX")"
+  if ! (cd "${fetch_dir}" && git init --quiet &&
+    git -c protocol.file.allow=always remote add origin "${source_url}" &&
+    git -c protocol.file.allow=always fetch --quiet --depth 1 origin "${sha}" &&
+    git checkout --quiet FETCH_HEAD); then
+    log_event error "git fetch failed" source="${source_url}" sha="${sha}" language=_plugins
+    rm -rf "${fetch_dir}"
+    return 1
+  fi
+
+  # Move the fetched tree contents into target/, atomically replacing any
+  # stale cached copy of the same slug/rev.
+  rm -rf "${target}"
+  mv "${fetch_dir}" "${target}"
+  printf "%s\n" "${sha}" >"${target}/.devrail.sha"
+}
+
+# compute_content_hash <dir>
+# Deterministic hash of all non-.git/ files in the directory.
+# Stable across machines (LC_ALL=C, find+sort+sha256sum chain).
+compute_content_hash() {
+  local dir="$1"
+  if [[ ! -d "${dir}" ]]; then
+    log_event error "content_hash directory missing" path="${dir}" language=_plugins
+    return 1
+  fi
+  (cd "${dir}" && find . -type f \
+    -not -path './.git/*' \
+    -not -name '.devrail.sha' \
+    -print0 |
+    sort -z |
+    xargs -0 sha256sum |
+    sha256sum |
+    cut -d' ' -f1)
+}
+
+# --- Main ---
+
+plugin_count="$(yq -r '.plugins // [] | length' "${DEVRAIL_YML}" 2>/dev/null || echo 0)"
+if [[ "${plugin_count}" == "0" ]]; then
+  log_event info "no plugins declared; lockfile not generated" language=_plugins
+  exit 0
+fi
+
+log_event info "resolving plugins" plugin_count:="${plugin_count}" language=_plugins
+
+# Build entries in a deterministic-by-source-URL order. We collect them in an
+# associative-array-keyed-by-source map, then sort the keys before writing.
+declare -a SOURCES_ORDER=()
+declare -A ENTRY_BY_SOURCE=()
+
+failed=0
+for i in $(seq 0 $((plugin_count - 1))); do
+  source_url="$(yq -r ".plugins[${i}].source // \"\"" "${DEVRAIL_YML}")"
+  rev="$(yq -r ".plugins[${i}].rev // \"\"" "${DEVRAIL_YML}")"
+
+  if [[ -z "${source_url}" || -z "${rev}" ]]; then
+    log_event error "plugin entry missing source or rev" \
+      index:="${i}" source="${source_url}" rev="${rev}" language=_plugins
+    failed=$((failed + 1))
+    continue
+  fi
+
+  slug="$(basename "${source_url}")"
+
+  if ! sha="$(resolve_ref "${source_url}" "${rev}")"; then
+    failed=$((failed + 1))
+    continue
+  fi
+
+  if ! fetch_to_cache "${source_url}" "${slug}" "${rev}" "${sha}"; then
+    failed=$((failed + 1))
+    continue
+  fi
+
+  manifest="${PLUGINS_DIR}/${slug}/${rev}/plugin.devrail.yml"
+  if [[ ! -r "${manifest}" ]]; then
+    log_event error "fetched tree is missing plugin.devrail.yml" \
+      source="${source_url}" rev="${rev}" path="${manifest}" language=_plugins
+    failed=$((failed + 1))
+    continue
+  fi
+
+  schema_version="$(yq -r '.schema_version' "${manifest}" 2>/dev/null || echo "")"
+  if [[ -z "${schema_version}" || "${schema_version}" == "null" ]]; then
+    log_event error "manifest schema_version not readable" \
+      source="${source_url}" rev="${rev}" language=_plugins
+    failed=$((failed + 1))
+    continue
+  fi
+
+  if ! content_hash="$(compute_content_hash "${PLUGINS_DIR}/${slug}/${rev}")"; then
+    failed=$((failed + 1))
+    continue
+  fi
+
+  # Build an entry for this source. Entries get sorted by `source` before write.
+  entry_block="$(printf '  - source: %s\n    rev: %s\n    sha: %s\n    schema_version: %s\n    content_hash: sha256:%s\n' \
+    "${source_url}" "${rev}" "${sha}" "${schema_version}" "${content_hash}")"
+  if [[ -z "${ENTRY_BY_SOURCE[${source_url}]:-}" ]]; then
+    SOURCES_ORDER+=("${source_url}")
+  fi
+  ENTRY_BY_SOURCE["${source_url}"]="${entry_block}"
+done
+
+if [[ "${failed}" -gt 0 ]]; then
+  log_event error "plugin resolver failed" failed:="${failed}" language=_plugins
+  # Atomic: do NOT touch the existing lockfile on partial failure.
+  exit 2
+fi
+
+# Sort sources alphabetically for deterministic lockfile output.
+mapfile -t SOURCES_SORTED < <(printf '%s\n' "${SOURCES_ORDER[@]}" | sort)
+
+{
+  printf 'schema_version: %s\n' "${LOCKFILE_SCHEMA_VERSION}"
+  printf 'plugins:\n'
+  for src in "${SOURCES_SORTED[@]}"; do
+    printf '%s\n' "${ENTRY_BY_SOURCE[${src}]}"
+  done
+} >"${LOCKFILE_TMP}"
+
+mv "${LOCKFILE_TMP}" "${LOCKFILE}"
+
+log_event info "lockfile written" path="${LOCKFILE}" plugins:="${plugin_count}" language=_plugins
+exit 0

--- a/tests/fixtures/plugin-repos/elixir-v1-tampered/README.md
+++ b/tests/fixtures/plugin-repos/elixir-v1-tampered/README.md
@@ -1,0 +1,5 @@
+# devrail-plugin-elixir (TAMPERED fixture)
+
+Same tag/rev as elixir-v1 but with modified content (different
+`plugin.devrail.yml` `description`). Used by the resolver smoke test to
+verify content_hash mismatch detection.

--- a/tests/fixtures/plugin-repos/elixir-v1-tampered/install.sh
+++ b/tests/fixtures/plugin-repos/elixir-v1-tampered/install.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Plugin install script — placeholder for Story 13.4's build pipeline to invoke.
+set -euo pipefail
+echo "elixir plugin v1.0.0 install (no-op for fixture)"

--- a/tests/fixtures/plugin-repos/elixir-v1-tampered/plugin.devrail.yml
+++ b/tests/fixtures/plugin-repos/elixir-v1-tampered/plugin.devrail.yml
@@ -1,0 +1,17 @@
+schema_version: 1
+name: elixir
+version: 1.0.0
+description: "Elixir language support — TAMPERED variant (description differs)"
+devrail_min_version: 1.10.0
+
+targets:
+  lint:
+    cmd: "mix credo --strict"
+  format_check:
+    cmd: "mix format --check-formatted"
+  test:
+    cmd: "mix test"
+
+gates:
+  lint: ["mix.exs"]
+  test: ["mix.exs", "test/"]

--- a/tests/fixtures/plugin-repos/elixir-v1/README.md
+++ b/tests/fixtures/plugin-repos/elixir-v1/README.md
@@ -1,0 +1,3 @@
+# devrail-plugin-elixir (fixture v1.0.0)
+
+Test fixture for the Story 13.3 plugin resolver smoke test. Not a real plugin.

--- a/tests/fixtures/plugin-repos/elixir-v1/install.sh
+++ b/tests/fixtures/plugin-repos/elixir-v1/install.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Plugin install script — placeholder for Story 13.4's build pipeline to invoke.
+set -euo pipefail
+echo "elixir plugin v1.0.0 install (no-op for fixture)"

--- a/tests/fixtures/plugin-repos/elixir-v1/plugin.devrail.yml
+++ b/tests/fixtures/plugin-repos/elixir-v1/plugin.devrail.yml
@@ -1,0 +1,17 @@
+schema_version: 1
+name: elixir
+version: 1.0.0
+description: "Elixir language support — Story 13.3 resolver fixture"
+devrail_min_version: 1.10.0
+
+targets:
+  lint:
+    cmd: "mix credo --strict"
+  format_check:
+    cmd: "mix format --check-formatted"
+  test:
+    cmd: "mix test"
+
+gates:
+  lint: ["mix.exs"]
+  test: ["mix.exs", "test/"]

--- a/tests/test-plugin-loader.sh
+++ b/tests/test-plugin-loader.sh
@@ -33,6 +33,28 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# write_matching_lockfile <workspace> <fixture-slug> <source> <rev>
+# Generates a `.devrail.lock` that matches the given source/rev/fixture so
+# `_plugins-verify` (Story 13.3 prereq) passes. Computes content_hash inside
+# the container against the bind-mounted fixture tree.
+write_matching_lockfile() {
+  local ws="$1" slug="$2" source="$3" rev="$4"
+  local content_hash
+  content_hash=$(docker run --rm \
+    -v "$FIXTURE_BASE/$slug/$rev:/plugin:ro" \
+    "$IMAGE" \
+    sh -c "cd /plugin && find . -type f -not -path './.git/*' -not -name '.devrail.sha' -print0 | sort -z | xargs -0 sha256sum | sha256sum | cut -d' ' -f1")
+  cat >"$ws/.devrail.lock" <<LOCK
+schema_version: 1
+plugins:
+  - source: $source
+    rev: $rev
+    sha: 0000000000000000000000000000000000000000
+    schema_version: 1
+    content_hash: sha256:$content_hash
+LOCK
+}
+
 # run_validator FIXTURE_NAME -> stderr from the validator, with exit code captured
 run_validator() {
   local fixture="$1"
@@ -140,13 +162,16 @@ mkdir -p "$WORKDIR/with-valid"
 cat >"$WORKDIR/with-valid/.devrail.yml" <<'YAML'
 languages: [elixir]
 plugins:
-  - source: github.com/community/valid-elixir
+  - source: valid-elixir
     rev: v1.0.0
     languages: [elixir]
 YAML
+write_matching_lockfile "$WORKDIR/with-valid" valid-elixir valid-elixir v1.0.0
 # Mount fixtures at /opt/devrail/plugins so the loader's rev-aware path
 # (/opt/devrail/plugins/<slug>/<rev>/plugin.devrail.yml) resolves to the
 # fixture (tests/fixtures/plugins/valid-elixir/v1.0.0/plugin.devrail.yml).
+# Source URL is the bare slug because basename(slug) == slug and the loader
+# only uses basename(source) to build the cache path.
 out="$(docker run --rm \
   -v "$WORKDIR/with-valid:/workspace" \
   -v "$REPO_ROOT/Makefile:/workspace/Makefile:ro" \
@@ -176,7 +201,7 @@ if [ -z "$cache_lint_cmd" ] || [ "$cache_lint_cmd" = "null" ]; then
 fi
 cache_source=$(yq -r '.plugins[0].source' "$cache_yaml")
 cache_rev=$(yq -r '.plugins[0].rev' "$cache_yaml")
-assert_eq "github.com/community/valid-elixir" "$cache_source" "cache resolution metadata: source"
+assert_eq "valid-elixir" "$cache_source" "cache resolution metadata: source"
 assert_eq "v1.0.0" "$cache_rev" "cache resolution metadata: rev"
 echo "    cache contains full manifest + resolution metadata: PASS"
 
@@ -185,10 +210,11 @@ mkdir -p "$WORKDIR/with-invalid"
 cat >"$WORKDIR/with-invalid/.devrail.yml" <<'YAML'
 languages: [bad-name]
 plugins:
-  - source: github.com/community/bad-name
+  - source: bad-name
     rev: v1.0.0
     languages: [bad-name]
 YAML
+write_matching_lockfile "$WORKDIR/with-invalid" bad-name bad-name v1.0.0
 out="$(docker run --rm \
   -v "$WORKDIR/with-invalid:/workspace" \
   -v "$REPO_ROOT/Makefile:/workspace/Makefile:ro" \
@@ -201,14 +227,20 @@ assert_eq "2" "$exit_code" "invalid-plugin exit code"
 echo "$out" >"$WORKDIR/with-invalid.events"
 assert_jq "$WORKDIR/with-invalid.events" 'select(.msg=="plugin loader complete" and .failed >= 1)' "invalid-plugin failure-summary event"
 
-echo "==> Integration: plugin entry missing rev → loader exits 2 with clear error"
+echo "==> Integration: plugin entry missing rev → fails fast at lockfile-verify"
+# Story 13.3 made `_plugins-verify` the first prereq of `_plugins-load`. The
+# verifier catches missing source/rev before the loader runs, so the failure
+# event is now `plugin entry missing source or rev` rather than the loader's
+# original `plugin entry missing rev field`. Either is acceptable as a
+# fail-fast signal — the test asserts the new path.
 mkdir -p "$WORKDIR/missing-rev"
 cat >"$WORKDIR/missing-rev/.devrail.yml" <<'YAML'
 languages: [elixir]
 plugins:
-  - source: github.com/community/valid-elixir
+  - source: valid-elixir
     languages: [elixir]
 YAML
+# No lockfile written — even with one, verifier rejects the missing rev.
 out="$(docker run --rm \
   -v "$WORKDIR/missing-rev:/workspace" \
   -v "$REPO_ROOT/Makefile:/workspace/Makefile:ro" \
@@ -219,6 +251,6 @@ out="$(docker run --rm \
   make _plugins-load 2>&1)" && exit_code=0 || exit_code=$?
 assert_eq "2" "$exit_code" "missing-rev exit code"
 echo "$out" >"$WORKDIR/missing-rev.events"
-assert_jq "$WORKDIR/missing-rev.events" 'select(.msg=="plugin entry missing rev field")' "missing-rev error event"
+assert_jq "$WORKDIR/missing-rev.events" 'select(.level=="error" and (.msg=="plugin entry missing source or rev" or .msg=="lockfile missing"))' "missing-rev error event"
 
 echo "==> All plugin-loader smoke checks passed"

--- a/tests/test-plugin-resolver.sh
+++ b/tests/test-plugin-resolver.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+# tests/test-plugin-resolver.sh — Validate the plugin resolver + lockfile (Story 13.3)
+#
+# Harness builds a local-filesystem git repo from a fixture tree (no network),
+# then drives `make plugins-update` and `_plugins-verify` against `file://` URLs.
+#
+# Cases covered:
+#   1. SHA passthrough — declare a 40-char SHA; lock entry's sha == declared rev
+#   2. Tag-to-SHA resolution — declare `v1.0.0`; lock entry's sha matches `git rev-parse v1.0.0`
+#   3. Branch rejection — declare `main`; resolver exits 2
+#   4. Lockfile determinism — running plugins-update twice produces byte-identical lockfile
+#   5. Idempotent fetch — second update doesn't re-clone
+#   6. Lockfile-mismatch — flip a rev in .devrail.lock; _plugins-verify exits 2
+#   7. Tampering detection — replace cached tree contents; _plugins-verify exits 2
+#   8. Missing-lockfile — declare a plugin, delete .devrail.lock; _plugins-verify exits 2
+#   9. No-regression — `.devrail.yml` without `plugins:` → _plugins-verify exits 0
+#  10. Unreachable source — file:///nonexistent path; resolver exits 2
+#  11. Atomic lockfile — failure after one successful resolution leaves prior lockfile intact
+#
+# Usage: bash tests/test-plugin-resolver.sh
+# Env:
+#   DEVRAIL_IMAGE  override image name (default: ghcr.io/devrail-dev/dev-toolchain)
+#   DEVRAIL_TAG    override image tag  (default: local)
+
+set -euo pipefail
+
+IMAGE="${DEVRAIL_IMAGE:-ghcr.io/devrail-dev/dev-toolchain}:${DEVRAIL_TAG:-local}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURE_BASE="${REPO_ROOT}/tests/fixtures/plugin-repos"
+WORKDIR="$(mktemp -d)"
+
+cleanup() {
+  if [ -n "${WORKDIR:-}" ] && [ -d "$WORKDIR" ]; then
+    docker run --rm -v "$WORKDIR:/cleanup" "$IMAGE" \
+      sh -c 'rm -rf /cleanup/* /cleanup/.[!.]* 2>/dev/null || true' >/dev/null 2>&1 || true
+    rmdir "$WORKDIR" 2>/dev/null || rm -rf "$WORKDIR" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+assert_eq() {
+  local expected="$1" actual="$2" context="$3"
+  if [ "$expected" != "$actual" ]; then
+    echo "FAIL [$context]: expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+assert_jq() {
+  local events="$1" filter="$2" context="$3"
+  if ! grep -E '^\{' "$events" | jq -e "$filter" >/dev/null 2>&1; then
+    echo "FAIL [$context]: jq filter '$filter' did not match any event in:" >&2
+    grep -E '^\{' "$events" | jq -c . >&2 2>/dev/null || cat "$events" >&2
+    exit 1
+  fi
+}
+
+# build_local_git_repo <fixture-name> <git-repo-output-dir>
+# Initialises a bare-bones git repo from a fixture tree, with one commit
+# tagged v1.0.0. Returns the path on stdout. Done inside docker so git config
+# stays consistent and host git noise is irrelevant.
+build_local_git_repo() {
+  local fixture="$1" out="$2"
+  mkdir -p "$out"
+  docker run --rm \
+    -v "$FIXTURE_BASE/$fixture:/src:ro" \
+    -v "$out:/repo" \
+    "$IMAGE" \
+    sh -c '
+      set -e
+      cp -a /src/. /repo/
+      cd /repo
+      git init --quiet
+      git config user.email "test@example.com"
+      git config user.name "Test"
+      git config commit.gpgsign false
+      git add -A
+      git commit --quiet -m "v1.0.0"
+      git tag v1.0.0
+      git checkout --quiet -b main
+      git checkout --quiet v1.0.0
+    '
+}
+
+# resolved_sha <git-repo-path> <ref>
+# Returns the SHA the ref resolves to, via docker (avoids host git config).
+resolved_sha() {
+  docker run --rm -v "$1:/repo:ro" "$IMAGE" \
+    sh -c 'cd /repo && git rev-parse '"$2"
+}
+
+# run_make <workspace-path> <args...>
+# Invokes make in a workspace, mounting the host Makefile read-only and
+# wiring DEVRAIL_PLUGINS_DIR + DEVRAIL_VERSION. Also mounts the entire
+# $WORKDIR at the same path inside the container so that `file://` URLs
+# embedded in fixture .devrail.yml files resolve identically inside and
+# outside the container. Echoes combined stderr+stdout. Sets RUN_EXIT.
+run_make() {
+  local ws="$1"
+  shift
+  RUN_EXIT=0
+  RUN_OUT="$(docker run --rm \
+    -v "$WORKDIR:$WORKDIR" \
+    -v "$ws:/workspace" \
+    -v "$REPO_ROOT/Makefile:/workspace/Makefile:ro" \
+    -v "$WORKDIR/plugins-cache:/opt/devrail/plugins" \
+    -e DEVRAIL_VERSION=1.10.0 \
+    -w /workspace \
+    "$IMAGE" \
+    make "$@" 2>&1)" || RUN_EXIT=$?
+}
+
+# --- Build the local-filesystem git source repos --------------------------
+echo "==> Building local-filesystem git repos from fixtures"
+build_local_git_repo elixir-v1 "$WORKDIR/elixir-repo"
+build_local_git_repo elixir-v1-tampered "$WORKDIR/elixir-tampered-repo"
+mkdir -p "$WORKDIR/plugins-cache"
+
+GIT_URL_VALID="file://$WORKDIR/elixir-repo"
+SHA_VALID="$(resolved_sha "$WORKDIR/elixir-repo" v1.0.0)"
+echo "    valid repo SHA at v1.0.0: $SHA_VALID"
+
+# --- Case 1: tag → SHA resolution -----------------------------------------
+echo "==> Case 1: tag → SHA resolution"
+mkdir -p "$WORKDIR/case1"
+cat >"$WORKDIR/case1/.devrail.yml" <<YAML
+languages: [elixir]
+plugins:
+  - source: $GIT_URL_VALID
+    rev: v1.0.0
+    languages: [elixir]
+YAML
+run_make "$WORKDIR/case1" _plugins-update
+echo "$RUN_OUT" >"$WORKDIR/case1.log"
+assert_eq "0" "$RUN_EXIT" "case1 exit code"
+[ -f "$WORKDIR/case1/.devrail.lock" ] || {
+  echo "FAIL [case1]: .devrail.lock missing" >&2
+  exit 1
+}
+LOCK_SHA="$(yq -r '.plugins[0].sha' "$WORKDIR/case1/.devrail.lock")"
+assert_eq "$SHA_VALID" "$LOCK_SHA" "case1 lockfile SHA"
+LOCK_HASH="$(yq -r '.plugins[0].content_hash' "$WORKDIR/case1/.devrail.lock")"
+[[ "$LOCK_HASH" =~ ^sha256:[a-f0-9]{64}$ ]] || {
+  echo "FAIL [case1]: content_hash malformed: $LOCK_HASH" >&2
+  exit 1
+}
+
+# --- Case 2: SHA passthrough ----------------------------------------------
+echo "==> Case 2: SHA passthrough"
+mkdir -p "$WORKDIR/case2"
+cat >"$WORKDIR/case2/.devrail.yml" <<YAML
+languages: [elixir]
+plugins:
+  - source: $GIT_URL_VALID
+    rev: $SHA_VALID
+    languages: [elixir]
+YAML
+run_make "$WORKDIR/case2" _plugins-update
+echo "$RUN_OUT" >"$WORKDIR/case2.log"
+assert_eq "0" "$RUN_EXIT" "case2 exit code"
+LOCK_SHA="$(yq -r '.plugins[0].sha' "$WORKDIR/case2/.devrail.lock")"
+assert_eq "$SHA_VALID" "$LOCK_SHA" "case2 SHA passthrough"
+
+# --- Case 3: branch rejection ---------------------------------------------
+echo "==> Case 3: branch rejection"
+mkdir -p "$WORKDIR/case3"
+cat >"$WORKDIR/case3/.devrail.yml" <<YAML
+languages: [elixir]
+plugins:
+  - source: $GIT_URL_VALID
+    rev: main
+    languages: [elixir]
+YAML
+run_make "$WORKDIR/case3" _plugins-update
+echo "$RUN_OUT" >"$WORKDIR/case3.log"
+assert_eq "2" "$RUN_EXIT" "case3 exit code"
+assert_jq "$WORKDIR/case3.log" 'select(.level=="error" and .msg=="branch refs are not allowed")' "case3 branch-rejection event"
+[ ! -f "$WORKDIR/case3/.devrail.lock" ] || {
+  echo "FAIL [case3]: .devrail.lock should NOT exist after failure" >&2
+  exit 1
+}
+
+# --- Case 4: lockfile determinism -----------------------------------------
+echo "==> Case 4: lockfile determinism"
+mkdir -p "$WORKDIR/case4"
+cat >"$WORKDIR/case4/.devrail.yml" <<YAML
+languages: [elixir]
+plugins:
+  - source: $GIT_URL_VALID
+    rev: v1.0.0
+    languages: [elixir]
+YAML
+run_make "$WORKDIR/case4" _plugins-update
+LOCK_FIRST="$(sha256sum "$WORKDIR/case4/.devrail.lock" | cut -d' ' -f1)"
+run_make "$WORKDIR/case4" _plugins-update
+LOCK_SECOND="$(sha256sum "$WORKDIR/case4/.devrail.lock" | cut -d' ' -f1)"
+assert_eq "$LOCK_FIRST" "$LOCK_SECOND" "case4 lockfile determinism"
+
+# --- Case 5: idempotent fetch ---------------------------------------------
+# After the first update, the cached tree should already exist. Second update
+# should log "plugin already cached" instead of "fetching plugin".
+echo "==> Case 5: idempotent fetch"
+mkdir -p "$WORKDIR/case5"
+cat >"$WORKDIR/case5/.devrail.yml" <<YAML
+languages: [elixir]
+plugins:
+  - source: $GIT_URL_VALID
+    rev: v1.0.0
+    languages: [elixir]
+YAML
+run_make "$WORKDIR/case5" _plugins-update >/dev/null
+run_make "$WORKDIR/case5" _plugins-update
+echo "$RUN_OUT" >"$WORKDIR/case5.log"
+assert_jq "$WORKDIR/case5.log" 'select(.level=="info" and .msg=="plugin already cached")' "case5 idempotency event"
+
+# --- Case 6: lockfile mismatch -------------------------------------------
+echo "==> Case 6: lockfile mismatch"
+mkdir -p "$WORKDIR/case6"
+cat >"$WORKDIR/case6/.devrail.yml" <<YAML
+languages: [elixir]
+plugins:
+  - source: $GIT_URL_VALID
+    rev: v1.0.0
+    languages: [elixir]
+YAML
+run_make "$WORKDIR/case6" _plugins-update >/dev/null
+# Tamper with the lockfile by flipping the rev
+sed -i 's/rev: v1\.0\.0/rev: v9.9.9/' "$WORKDIR/case6/.devrail.lock"
+run_make "$WORKDIR/case6" _plugins-verify
+echo "$RUN_OUT" >"$WORKDIR/case6.log"
+assert_eq "2" "$RUN_EXIT" "case6 verify exit code"
+assert_jq "$WORKDIR/case6.log" 'select(.level=="error" and .msg=="lockfile mismatch")' "case6 mismatch event"
+
+# --- Case 7: tampering detection (cached tree changed) -------------------
+echo "==> Case 7: tampering detection"
+mkdir -p "$WORKDIR/case7"
+cat >"$WORKDIR/case7/.devrail.yml" <<YAML
+languages: [elixir]
+plugins:
+  - source: $GIT_URL_VALID
+    rev: v1.0.0
+    languages: [elixir]
+YAML
+run_make "$WORKDIR/case7" _plugins-update >/dev/null
+# Replace cached tree contents with the "tampered" fixture (without re-running
+# plugins-update, so the lockfile's content_hash records the original tree).
+docker run --rm \
+  -v "$FIXTURE_BASE/elixir-v1-tampered:/src:ro" \
+  -v "$WORKDIR/plugins-cache:/cache" \
+  "$IMAGE" \
+  sh -c 'rm -rf /cache/elixir-repo/v1.0.0/* /cache/elixir-repo/v1.0.0/.devrail.sha 2>/dev/null; cp -a /src/. /cache/elixir-repo/v1.0.0/'
+run_make "$WORKDIR/case7" _plugins-verify
+echo "$RUN_OUT" >"$WORKDIR/case7.log"
+assert_eq "2" "$RUN_EXIT" "case7 verify exit code"
+assert_jq "$WORKDIR/case7.log" 'select(.level=="error" and (.msg | contains("content_hash mismatch")))' "case7 tampering event"
+
+# Re-fetch clean tree for downstream cases (Case 7 left the cache tampered).
+run_make "$WORKDIR/case7" _plugins-update >/dev/null
+
+# --- Case 8: missing lockfile --------------------------------------------
+echo "==> Case 8: missing lockfile"
+mkdir -p "$WORKDIR/case8"
+cat >"$WORKDIR/case8/.devrail.yml" <<YAML
+languages: [elixir]
+plugins:
+  - source: $GIT_URL_VALID
+    rev: v1.0.0
+    languages: [elixir]
+YAML
+# Note: no .devrail.lock written
+run_make "$WORKDIR/case8" _plugins-verify
+echo "$RUN_OUT" >"$WORKDIR/case8.log"
+assert_eq "2" "$RUN_EXIT" "case8 exit code"
+assert_jq "$WORKDIR/case8.log" 'select(.level=="error" and .msg=="lockfile missing")' "case8 missing-lockfile event"
+
+# --- Case 9: no plugins regression ---------------------------------------
+echo "==> Case 9: no-plugins regression"
+mkdir -p "$WORKDIR/case9"
+cat >"$WORKDIR/case9/.devrail.yml" <<'YAML'
+languages: [bash]
+YAML
+run_make "$WORKDIR/case9" _plugins-verify
+assert_eq "0" "$RUN_EXIT" "case9 no-plugins exit code"
+[ ! -f "$WORKDIR/case9/.devrail.lock" ] || {
+  echo "FAIL [case9]: should not require .devrail.lock" >&2
+  exit 1
+}
+
+# --- Case 10: unreachable source -----------------------------------------
+echo "==> Case 10: unreachable source"
+mkdir -p "$WORKDIR/case10"
+cat >"$WORKDIR/case10/.devrail.yml" <<'YAML'
+languages: [elixir]
+plugins:
+  - source: file:///nonexistent/path/devrail-plugin-elixir
+    rev: v1.0.0
+    languages: [elixir]
+YAML
+run_make "$WORKDIR/case10" _plugins-update
+echo "$RUN_OUT" >"$WORKDIR/case10.log"
+assert_eq "2" "$RUN_EXIT" "case10 exit code"
+assert_jq "$WORKDIR/case10.log" 'select(.level=="error" and (.msg=="ref not found at source" or .msg=="git fetch failed"))' "case10 unreachable event"
+
+# --- Case 11: atomic lockfile (partial-failure preserves prior lockfile) -
+echo "==> Case 11: atomic lockfile on partial failure"
+mkdir -p "$WORKDIR/case11"
+cat >"$WORKDIR/case11/.devrail.yml" <<YAML
+languages: [elixir]
+plugins:
+  - source: $GIT_URL_VALID
+    rev: v1.0.0
+    languages: [elixir]
+YAML
+run_make "$WORKDIR/case11" _plugins-update >/dev/null
+LOCK_GOOD_HASH="$(sha256sum "$WORKDIR/case11/.devrail.lock" | cut -d' ' -f1)"
+# Now add a second plugin pointing at an unreachable source. Resolver should
+# fail on the second entry without overwriting the existing lockfile.
+cat >"$WORKDIR/case11/.devrail.yml" <<YAML
+languages: [elixir, bogus]
+plugins:
+  - source: $GIT_URL_VALID
+    rev: v1.0.0
+    languages: [elixir]
+  - source: file:///nonexistent/devrail-plugin-bogus
+    rev: v1.0.0
+    languages: [bogus]
+YAML
+run_make "$WORKDIR/case11" _plugins-update
+assert_eq "2" "$RUN_EXIT" "case11 exit code (failure expected)"
+LOCK_AFTER_HASH="$(sha256sum "$WORKDIR/case11/.devrail.lock" | cut -d' ' -f1)"
+assert_eq "$LOCK_GOOD_HASH" "$LOCK_AFTER_HASH" "case11 atomic lockfile preserved"
+
+echo "==> All plugin-resolver smoke checks passed (11/11)"


### PR DESCRIPTION
## Summary

Implements `make plugins-update` and `_plugins-verify` for the v1.10.x plugin architecture. Builds on Story 13.2's loader (PR #31, v1.10.0) + review fixes (PR #33, v1.10.1).

## What's in the PR

### \`scripts/plugin-resolver.sh\`
For each plugin in \`.devrail.yml\`:
- Resolve \`rev:\` to an immutable SHA via \`git ls-remote\` (SHA passthrough for 40-char hex; tag-to-SHA via ls-remote, peeled form preferred for annotated tags).
- **Reject branch refs** with a clear error event.
- Fetch the tree to \`\${DEVRAIL_PLUGINS_DIR:-/opt/devrail/plugins}/<slug>/<rev>/\` (matches the path Story 13.2's loader reads).
- Compute deterministic \`content_hash\` (LC_ALL=C, find+sort+sha256sum, excludes \`.git/\` + \`.devrail.sha\`).
- Write \`.devrail.lock\` atomically via temp+rename. Sorted by source for deterministic diffs.
- **Idempotent** — second update on the same rev/sha is a no-op.

### \`scripts/plugin-lockfile-verify.sh\`
Fast verification used as \`_plugins-load\` prereq on every \`make check\`:
- Cross-check every yml plugin entry has a matching lock entry with the same rev.
- Re-compute \`content_hash\` on the cached tree, compare to recorded hash → detects tag-rebase tampering.
- **No-op** when \`.devrail.yml\` has no \`plugins:\` (v1.9.x/v1.10.x regression-safe).

### Makefile
- New public \`plugins-update\` target.
- New internal \`_plugins-update\` (resolver) and \`_plugins-verify\` (verifier).
- \`_plugins-load\` prereq updated: \`_check-config → _plugins-verify → _plugins-load\`.

### Fixtures + tests
- \`tests/fixtures/plugin-repos/elixir-v1/\` + \`elixir-v1-tampered/\` — fixture trees (no \`.git/\`); harness initialises git per case.
- \`tests/test-plugin-resolver.sh\` — **11-case smoke**.
- \`tests/test-plugin-loader.sh\` — updated integration cases to write a matching \`.devrail.lock\` via a new \`write_matching_lockfile\` helper.

## Acceptance criteria from Story 13.3

- [x] AC 1 — \`make plugins-update\` resolves rev via \`git ls-remote\`; SHA passthrough; tag-to-SHA; branch refs rejected
- [x] AC 2 — \`.devrail.lock\` written with \`source/rev/sha/schema_version/content_hash\`; sorted; top-level \`schema_version: 1\`
- [x] AC 3 — clone lands at \`<plugins-dir>/<slug>/<rev>/\`; idempotent re-fetch; atomic via temp+rename
- [x] AC 4 — \`_plugins-verify\` enforces yml↔lock consistency + content_hash; structured errors with remediation hints
- [x] AC 5 — missing lockfile when plugins declared exits 2; absence is fine when no plugins declared
- [x] AC 6 — unreachable source emits structured error; lockfile NOT partially written
- [x] AC 7 — \`tests/test-plugin-resolver.sh\` covers all 11 cases via local-filesystem git fixtures (no network)

## Test plan

- [x] Image rebuilds cleanly
- [x] \`tests/test-plugin-resolver.sh\` — 11/11
- [x] \`tests/test-plugin-loader.sh\` — 11/11 (regression-safe with new \`_plugins-verify\` prereq)
- [x] \`tests/smoke-rails.sh\` — 4/4 (regression-safe)
- [x] \`make _check\` on dev-toolchain itself — pass
- [ ] CI green on this PR

## Implementation note

git 2.38+ blocks the \`file://\` protocol from non-interactive contexts (CVE-2022-39253 mitigation). Resolver passes \`-c protocol.file.allow=always\` to \`ls-remote\`/\`fetch\`/\`remote add\`. Production plugins use \`https://\` or \`ssh://\` and aren't affected; only the local-fixture test harness exercises this code path.

## Out of scope (next stories)

- **Story 13.4** — extended-image build pipeline (\`Dockerfile.devrail\` generation)
- **Story 13.5** — execution loop (runs plugin commands during \`_lint\`/etc.)
- **Story 13.6** — v1.11.0 release with all of the above

🤖 Generated with [Claude Code](https://claude.com/claude-code)