### PR TITLE
fix(makefile): tipsyhive v1.11 sync issues (#41, #42, #43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Issue #41:** Makefile's `LANGUAGES` invocation of `yq` now uses `-r`
+  (raw output). yq v3 (kislyuk's Python wrapper, packaged as `yq` on
+  Debian/Ubuntu) returns JSON-formatted scalars by default — without
+  `-r`, `.languages[]` returned `"ruby"` (quoted) and `HAS_RUBY` never
+  matched. With `-r`, behaviour is identical between yq v3 and v4.
+- **Issue #42:** Container no longer exports `BUNDLE_PATH=/usr/local/bundle`
+  at runtime. Bundler precedence rule (envvar beats project
+  `.bundle/config`) was silently overriding consumer projects with
+  `BUNDLE_PATH: vendor/bundle`, breaking `bundle exec` for
+  project-pinned gems with `Bundler::GemNotFound`. With the envvar
+  unset, the project's `.bundle/config` wins; direct gem invocations
+  (`rubocop`, `reek`, `rspec`) still resolve from `/usr/local/bundle`
+  via `GEM_HOME` and the `PATH` entry for `/usr/local/bundle/bin`.
+- **Issue #43:** Makefile's `_format` no longer passes `--check` to
+  `rubocop` — it's not a valid rubocop flag and broke every Rails
+  project with rubocop in its Gemfile. Default rubocop behaviour is
+  already "report, don't autocorrect"; `--fail-level error` (still
+  passed) gates the exit code.
+
 ## [1.11.0] - 2026-05-05
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -187,8 +187,15 @@ COPY --from=ruby-builder /usr/local/bundle /usr/local/bundle
 RUN ln -sf libruby.so.3.4 /usr/local/lib/libruby.so.3.4.0 \
     && ln -sf libruby.so.3.4 /usr/local/lib/libruby.so \
     && ldconfig
+# Bundler envvars. We DO NOT export BUNDLE_PATH at runtime — Bundler's
+# precedence is envvar > project `.bundle/config`, which silently
+# overrides a consumer's `BUNDLE_PATH: vendor/bundle` and breaks
+# `bundle exec` for project-pinned gems (Issue #42). With BUNDLE_PATH
+# unset, Bundler falls back to GEM_HOME — direct `rubocop` / `reek` /
+# `rspec` invocations from `/usr/local/bundle/bin` (already on PATH)
+# still resolve the container's bundled gems, and `bundle exec` in a
+# consumer project honours the project's `.bundle/config`.
 ENV GEM_HOME=/usr/local/bundle
-ENV BUNDLE_PATH=/usr/local/bundle
 ENV BUNDLE_SILENCE_ROOT_WARNING=1
 ENV BUNDLE_APP_CONFIG=/usr/local/bundle
 

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ RUBY_EXEC_FOR = $(if $(and $(wildcard Gemfile.lock),$(shell grep -m1 -E "^[[:spa
 # Computed before DOCKER_RUN so HAS_<LANG> can influence container env (e.g.
 # BUNDLE_APP_CONFIG override for Ruby projects — issue #30).
 # ---------------------------------------------------------------------------
-LANGUAGES      := $(shell yq '.languages[]' $(DEVRAIL_CONFIG) 2>/dev/null)
+LANGUAGES      := $(shell yq -r '.languages[]' $(DEVRAIL_CONFIG) 2>/dev/null)
 HAS_PYTHON     := $(filter python,$(LANGUAGES))
 HAS_BASH       := $(filter bash,$(LANGUAGES))
 HAS_TERRAFORM  := $(filter terraform,$(LANGUAGES))
@@ -656,7 +656,7 @@ _format: _plugins-load
 		for p in $(RUBY_PATHS); do [ -d "$$p" ] && ruby_paths="$$ruby_paths $$p"; done; \
 		ruby_paths=$${ruby_paths# }; \
 		if [ -n "$$ruby_paths" ]; then \
-			$(call RUBY_EXEC_FOR,rubocop)rubocop --check --fail-level error $$ruby_paths || { overall_exit=1; failed_languages="$${failed_languages}\"ruby\","; }; \
+			$(call RUBY_EXEC_FOR,rubocop)rubocop --fail-level error $$ruby_paths || { overall_exit=1; failed_languages="$${failed_languages}\"ruby\","; }; \
 		else \
 			echo '{"level":"info","msg":"skipping ruby format: none of RUBY_PATHS exist (override with RUBY_PATHS=...)","language":"ruby"}' >&2; \
 		fi; \


### PR DESCRIPTION
## Summary

Closes #41, #42, #43. Three small fixes surfaced when tipsyhive synced its Makefile to v1.11.0.

- **#41 yq `-r`** — Makefile `LANGUAGES` was returning JSON-quoted scalars on hosts with yq v3, so `HAS_RUBY` never matched and `BUNDLE_APP_CONFIG` never got injected. One-character fix.
- **#42 BUNDLE_PATH envvar** — Dockerfile exported `BUNDLE_PATH=/usr/local/bundle` which Bundler precedence-treats as higher than project `.bundle/config`. Removed the envvar; project configs now win. Direct `rubocop`/`reek`/etc. invocations still resolve via `GEM_HOME` + PATH.
- **#43 `rubocop --check`** — not a valid flag. Removed.

## Test plan

- [x] `bash tests/smoke-rails.sh` — 4/4 pass (lint scoping, bundle install, .bundle/config override, rubocop)
- [x] `make check` on dev-toolchain itself — pass
- [x] `bundle config` inside rebuilt container — BUNDLE_PATH no longer shown
- [x] Direct `rubocop`, `reek`, `brakeman` invocations resolve their gems
- [x] `rubocop --check` confirmed broken on stock rubocop; dropping the flag fixes _format
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)