### PR TITLE
test(makefile): surface captured RUN_OUT on assert_eq failure

### DIFF
--- a/tests/test-plugin-build-pipeline.sh
+++ b/tests/test-plugin-build-pipeline.sh
@@ -40,6 +40,13 @@ assert_eq() {
   local expected="$1" actual="$2" context="$3"
   if [ "$expected" != "$actual" ]; then
     echo "FAIL [$context]: expected '$expected', got '$actual'" >&2
+    # If the most-recent run captured output, surface it so CI failures
+    # aren't black boxes. Tests that don't use RUN_OUT just print empty.
+    if [ -n "${RUN_OUT:-}" ]; then
+      echo "--- captured output ---" >&2
+      echo "$RUN_OUT" >&2
+      echo "--- end captured output ---" >&2
+    fi
     exit 1
   fi
 }


### PR DESCRIPTION
## Summary

The plugin build-pipeline smoke test captures `make _extended-image` output into RUN_OUT and only prints it on the SECOND assertion (the grep for the build-event message). When `assert_eq` on exit code fails first, RUN_OUT is silently dropped — CI failures become black boxes.

Hit this debugging the post-#44-merge CI failure on main (Case 5 fails on CI, passes locally). With this change, future assert_eq failures dump RUN_OUT so the docker build output is visible.

## Test plan

- [x] Local test still passes (RUN_OUT empty for the non-capturing cases is harmless)
- [ ] CI green