### PR TITLE
fix(container): apt-get upgrade in runtime stage for Debian CVE patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Apply Debian security upgrades on every image build.** The runtime
+  stage's `apt-get install` no longer trusts the base image to be at
+  current patch level — an `apt-get upgrade -y --no-install-recommends`
+  in the same layer pulls security-patched versions of base packages
+  (libcap2, libsystemd0, libudev1, etc.). Closes the gap that caused
+  Trivy's blocking OS-package scan to fail on v1.11.2 after Debian
+  shipped CVE-2026-4878 (libcap2 privilege-escalation TOCTOU race) and
+  CVE-2026-29111 (systemd arbitrary code execution / DoS) without the
+  `debian:bookworm-slim` manifest catching up.
+
 ### Fixed
 
 - **Issue #41:** Makefile's `LANGUAGES` invocation of `yq` now uses `-r`

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,23 +93,29 @@ LABEL org.opencontainers.image.description="DevRail developer toolchain containe
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.version="${DEVRAIL_VERSION}"
 
-# Base system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    bash \
-    ca-certificates \
-    curl \
-    git \
-    gnupg \
-    jq \
-    make \
-    python3 \
-    python3-pip \
-    python3-venv \
-    build-essential \
-    libyaml-dev \
-    shellcheck \
-    unzip \
-    wget \
+# Base system dependencies. `apt-get upgrade` pulls security-patched
+# versions of packages already in the base image (libcap2, libsystemd0,
+# libudev1, etc.) — without it, Trivy's blocking OS-package scan rejects
+# the build when Debian publishes a CVE fix before the base-image
+# manifest catches up. Same layer as `install` to keep image size down.
+RUN apt-get update \
+    && apt-get upgrade -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        jq \
+        make \
+        python3 \
+        python3-pip \
+        python3-venv \
+        build-essential \
+        libyaml-dev \
+        shellcheck \
+        unzip \
+        wget \
     && rm -rf /var/lib/apt/lists/*
 
 # Install yq for YAML parsing in Makefile language detection


### PR DESCRIPTION
## Summary

Trivy's blocking OS-package scan failed on v1.11.2 (run [26108273647](https://github.com/devrail-dev/dev-toolchain/actions/runs/26108273647/job/76778113651)) with three HIGH vulnerabilities:

| Library | CVE | Title |
|---|---|---|
| `libcap2` | CVE-2026-4878 | Privilege escalation via TOCTOU race in `cap_set_file()` |
| `libsystemd0` | CVE-2026-29111 | Arbitrary code execution / DoS via spurious IPC |
| `libudev1` | CVE-2026-29111 | (same root cause, transitive) |

All three have Debian-archive fixes available. The runtime stage's existing `apt-get install` doesn't refresh already-installed packages from the `debian:bookworm-slim` base, so newly-released CVE patches don't land until either (a) the base manifest gets updated, or (b) we explicitly `apt-get upgrade`.

Adding `apt-get upgrade -y --no-install-recommends` to the same layer as `apt-get install` is the canonical fix. Same layer keeps image size down.

## Caveat: not validated locally

The local rebuild flaked on `install-kotlin.sh` with `curl: (56) Failure when receiving data` mid-build. Network blip, not related to the Dockerfile change. CI is the canonical validation environment for this kind of change — letting CI green-light it.

## Heads-up: tag history

While debugging this I noticed `v1.11.1` and `v1.11.2` tags exist but neither has a corresponding `chore(release): prepare ...` commit, and neither triggered the `Build and Publish Container` workflow (the v1.11.1 tag actually points at the v1.11.0 release commit). They look like stale/accidental retags. After this PR merges, I'd suggest cutting via `make release VERSION=1.11.3` so the CHANGELOG and tag are consistent again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)